### PR TITLE
Support environment variable for hpre/cipher/digest

### DIFF
--- a/README
+++ b/README
@@ -166,3 +166,48 @@ openssl ec -in SM2PrivateKey.pem -pubout -out SM2PublicKey.pem
 openssl speed -elapsed -engine uadk ecdsap256
 openssl speed -elapsed -engine uadk -async_jobs 1 ecdsap256
 ```
+
+Environment variable of uadk engine
+===================================
+Introduction
+------------
+Through the environment variable function, users can configure the number of
+queue resources that can be applied by different algorithms by setting the
+algorithm switch in the openssl.cnf file.
+
+Usage
+-----
+1. Firstly, modify the openssl.cnf file, add the following settings at the beginning of this file:
+
+```
+openssl_cnf = openssl_def
+[openssl_def]
+engines = engine_section
+[engine_section]
+uadk = uadk_section
+[uadk_section]
+UADK_CMD_ENABLE_RSA_ENV = 1
+UADK_CMD_ENABLE_DH_ENV = 1
+UADK_CMD_ENABLE_CIPHER_ENV = 1
+UADK_CMD_ENABLE_DIGEST_ENV = 1
+UADK_CMD_ENABLE_ECC_ENV = 1
+```
+Note: * The number 1 for enable environment variable, and 0 for disable environment variable.
+      * By default, you can find openssl.cnf file under /usr/local/ssl/ path.
+
+2. Secondly, use "export" command to set queue number.
+For example,
+```
+export WD_RSA_CTX_NUM="sync:2@0,async:4@0"
+export WD_DH_CTX_NUM="sync:2@0,async:4@0"
+export WD_CIPHER_CTX_NUM="sync:2@2,async:4@2"
+export WD_DIGEST_CTX_NUM="sync:2@2,async:4@2"
+export WD_ECC_CTX_NUM="sync:2@0,async:4@0"
+```
+Note: * You can write these commands into ~/.bashrc file and source it, or just
+      input temporarily.
+      * "sync" indicates synchronous mode, "async" indicates asynchronous mode.
+      * "sync:2@0" means request 2 queues on numa-0 node, under synchronous mode.
+      * "async:2@0" means request 2 queues on numa-0 node, under asynchronous mode.
+      * If you do not perform the second step, the engine will use the default
+      setting:"sync:2@0, async:2@0" to request queues from hardware.

--- a/src/e_uadk.c
+++ b/src/e_uadk.c
@@ -59,6 +59,30 @@ static const ENGINE_CMD_DEFN g_uadk_cmd_defns[] = {
 		ENGINE_CMD_FLAG_NUMERIC
 	},
 	{
+		UADK_CMD_ENABLE_DIGEST_ENV,
+		"UADK_CMD_ENABLE_DIGEST_ENV",
+		"Enable or Disable digest engine environment variable.",
+		ENGINE_CMD_FLAG_NUMERIC
+	},
+	{
+		UADK_CMD_ENABLE_RSA_ENV,
+		"UADK_CMD_ENABLE_RSA_ENV",
+		"Enable or Disable rsa engine environment variable.",
+		ENGINE_CMD_FLAG_NUMERIC
+	},
+	{
+		UADK_CMD_ENABLE_DH_ENV,
+		"UADK_CMD_ENABLE_DH_ENV",
+		"Enable or Disable dh engine environment variable.",
+		ENGINE_CMD_FLAG_NUMERIC
+	},
+	{
+		UADK_CMD_ENABLE_ECC_ENV,
+		"UADK_CMD_ENABLE_ECC_ENV",
+		"Enable or Disable ecc engine environment variable.",
+		ENGINE_CMD_FLAG_NUMERIC
+	},
+	{
 		0, NULL, NULL, 0
 	}
 };
@@ -80,7 +104,10 @@ struct uadk_alg_env_enabled {
 
 static struct uadk_alg_env_enabled uadk_env_enabled[] = {
 	{ "cipher", 0 },
-	{ "digest", 0 }
+	{ "digest", 0 },
+	{ "rsa", 0 },
+	{ "dh", 0 },
+	{ "ecc", 0 }
 };
 
 int uadk_is_env_enabled(char *alg_name)
@@ -119,7 +146,7 @@ static int uadk_engine_ctrl(ENGINE *e, int cmd, long i,
 	(void)p;
 	(void)f;
 
-	if (e == NULL) {
+	if (!e) {
 		fprintf(stderr, "Null Engine\n");
 		return 0;
 	}
@@ -127,6 +154,18 @@ static int uadk_engine_ctrl(ENGINE *e, int cmd, long i,
 	switch (cmd) {
 	case UADK_CMD_ENABLE_CIPHER_ENV:
 		uadk_set_env_enabled("cipher", i);
+		break;
+	case UADK_CMD_ENABLE_DIGEST_ENV:
+		uadk_set_env_enabled("digest", i);
+		break;
+	case UADK_CMD_ENABLE_RSA_ENV:
+		uadk_set_env_enabled("rsa", i);
+		break;
+	case UADK_CMD_ENABLE_DH_ENV:
+		uadk_set_env_enabled("dh", i);
+		break;
+	case UADK_CMD_ENABLE_ECC_ENV:
+		uadk_set_env_enabled("ecc", i);
 		break;
 	default:
 		ret = 0;

--- a/src/e_uadk.c
+++ b/src/e_uadk.c
@@ -110,7 +110,7 @@ static struct uadk_alg_env_enabled uadk_env_enabled[] = {
 	{ "ecc", 0 }
 };
 
-int uadk_is_env_enabled(char *alg_name)
+int uadk_e_is_env_enabled(char *alg_name)
 {
 	int len = ARRAY_SIZE(uadk_env_enabled);
 	int i = 0;
@@ -124,7 +124,7 @@ int uadk_is_env_enabled(char *alg_name)
 	return 0;
 }
 
-static void uadk_set_env_enabled(char *alg_name, __u8 value)
+static void uadk_e_set_env_enabled(char *alg_name, __u8 value)
 {
 	int len = ARRAY_SIZE(uadk_env_enabled);
 	int i = 0;
@@ -137,6 +137,27 @@ static void uadk_set_env_enabled(char *alg_name, __u8 value)
 
 		i++;
 	}
+}
+
+int uadk_e_set_env(const char *var_name, int numa_id)
+{
+	char env_string[ENV_STRING_LEN] = {0};
+	char *var_s;
+	int ret;
+
+	var_s = getenv(var_name);
+	if (!var_s || !strlen(var_s)) {
+		ret = snprintf(env_string, ENV_STRING_LEN, "%s%d%s%d",
+			       "sync:2@", numa_id, ",async:2@", numa_id);
+		if (ret < 0)
+			return ret;
+
+		ret = setenv(var_name, env_string, 1);
+		if (ret < 0)
+			return ret;
+	}
+
+	return 0;
 }
 
 static int uadk_engine_ctrl(ENGINE *e, int cmd, long i,
@@ -153,19 +174,19 @@ static int uadk_engine_ctrl(ENGINE *e, int cmd, long i,
 
 	switch (cmd) {
 	case UADK_CMD_ENABLE_CIPHER_ENV:
-		uadk_set_env_enabled("cipher", i);
+		uadk_e_set_env_enabled("cipher", i);
 		break;
 	case UADK_CMD_ENABLE_DIGEST_ENV:
-		uadk_set_env_enabled("digest", i);
+		uadk_e_set_env_enabled("digest", i);
 		break;
 	case UADK_CMD_ENABLE_RSA_ENV:
-		uadk_set_env_enabled("rsa", i);
+		uadk_e_set_env_enabled("rsa", i);
 		break;
 	case UADK_CMD_ENABLE_DH_ENV:
-		uadk_set_env_enabled("dh", i);
+		uadk_e_set_env_enabled("dh", i);
 		break;
 	case UADK_CMD_ENABLE_ECC_ENV:
-		uadk_set_env_enabled("ecc", i);
+		uadk_e_set_env_enabled("ecc", i);
 		break;
 	default:
 		ret = 0;

--- a/src/uadk.h
+++ b/src/uadk.h
@@ -20,6 +20,8 @@
 #include <uadk/wd.h>
 
 #define ARRAY_SIZE(x)	(sizeof(x) / sizeof((x)[0]))
+#define ENV_STRING_LEN	256
+
 enum {
 	KUNPENG920,
 	KUNPENG930,
@@ -36,4 +38,5 @@ extern void uadk_destroy_ecc(void);
 extern int uadk_e_bind_dh(ENGINE *e);
 extern void uadk_e_destroy_dh(void);
 extern int uadk_bind_ecc(ENGINE *e);
+extern int uadk_is_env_enabled(char *alg_name);
 #endif

--- a/src/uadk.h
+++ b/src/uadk.h
@@ -38,5 +38,6 @@ extern void uadk_destroy_ecc(void);
 extern int uadk_e_bind_dh(ENGINE *e);
 extern void uadk_e_destroy_dh(void);
 extern int uadk_bind_ecc(ENGINE *e);
-extern int uadk_is_env_enabled(char *alg_name);
+extern int uadk_e_is_env_enabled(char *alg_name);
+extern int uadk_e_set_env(const char *var_name, int numa_id);
 #endif

--- a/src/uadk_ecx.c
+++ b/src/uadk_ecx.c
@@ -92,6 +92,7 @@ static int x25519_init(EVP_PKEY_CTX *ctx)
 
 	setup.alg = "x25519";
 	setup.key_bits = X25519_KEYBITS;
+	setup.numa = uadk_e_ecc_get_numa_id();
 	x25519_ctx->sess = wd_ecc_alloc_sess(&setup);
 	if (!x25519_ctx->sess) {
 		fprintf(stderr, "failed to alloc sess\n");
@@ -140,6 +141,7 @@ static int x448_init(EVP_PKEY_CTX *ctx)
 	memset(x448_ctx, 0, sizeof(struct ecx_ctx));
 	setup.alg = "x448";
 	setup.key_bits = X448_KEYBITS;
+	setup.numa = uadk_e_ecc_get_numa_id();
 	x448_ctx->sess = wd_ecc_alloc_sess(&setup);
 	if (!x448_ctx->sess) {
 		fprintf(stderr, "failed to alloc sess\n");

--- a/src/uadk_pkey.h
+++ b/src/uadk_pkey.h
@@ -36,6 +36,7 @@
 #define UADK_ECC_PUBKEY_PARAM_NUM	2
 #define UADK_ECC_PADDING		7
 #define UADK_ECDH_CV_NUM		8
+#define ENV_ENABLED			1
 
 struct uadk_pkey_meth {
 	EVP_PKEY_METHOD *sm2;
@@ -68,6 +69,7 @@ int uadk_x448_create_pmeth(struct uadk_pkey_meth *pkey_meth);
 int uadk_x25519_create_pmeth(struct uadk_pkey_meth *pkey_meth);
 void uadk_ec_delete_meth(void);
 int uadk_bind_ec(ENGINE *e);
+int uadk_e_ecc_get_numa_id(void);
 
 
 #endif


### PR DESCRIPTION
Support environment variable for hpre/cipher/digest.
Through the environment variable function, users can configure the number of queue resources that can be applied by different algorithms by setting the algorithm switch in the openssl.cnf file.
