### PR TITLE
cipher: solving the problem of software and hardware non-consistent

### DIFF
--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -934,11 +934,11 @@ static int bind_v2_cipher(void)
 			  sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
 			  uadk_e_do_cipher, uadk_e_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_128_xts, 1, 32, 0, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV,
+	UADK_CIPHER_DESCR(aes_128_xts, 1, 32, 16, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV,
 			  sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
 			  uadk_e_do_cipher, uadk_e_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_256_xts, 1, 64, 0, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV,
+	UADK_CIPHER_DESCR(aes_256_xts, 1, 64, 16, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV,
 			  sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
 			  uadk_e_do_cipher, uadk_e_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);


### PR DESCRIPTION
The xts-aes need to setting the iv lens, it will cause the result of
software and hardware is non-consistent.

Signed-off-by: Kai Ye <yekai13@huawei.com>