### PR TITLE
engine/sched: modify sched interface

### DIFF
--- a/src/uadk.h
+++ b/src/uadk.h
@@ -18,6 +18,7 @@
 #define UADK_H
 #include <openssl/engine.h>
 #include <uadk/wd.h>
+#include <uadk/wd_sched.h>
 
 #define ARRAY_SIZE(x)	(sizeof(x) / sizeof((x)[0]))
 #define ENV_STRING_LEN	256

--- a/src/uadk_ec.c
+++ b/src/uadk_ec.c
@@ -146,6 +146,7 @@ static int get_smallest_hw_keybits(int bits)
 static handle_t ecc_alloc_sess(const EC_KEY *eckey, char *alg)
 {
 	char buff[UADK_ECC_MAX_KEY_BYTES * UADK_ECC_CV_PARAM_NUM];
+	struct sched_params sch_p = {0};
 	struct wd_ecc_sess_setup sp;
 	struct wd_ecc_curve param;
 	struct uacce_dev *dev;
@@ -176,7 +177,8 @@ static handle_t ecc_alloc_sess(const EC_KEY *eckey, char *alg)
 	sp.key_bits = get_smallest_hw_keybits(key_bits);
 	sp.rand.cb = uadk_ecc_get_rand;
 	sp.rand.usr = (void *)order;
-	sp.numa = dev->numa_id;
+	sch_p.numa_id = dev->numa_id;
+	sp.sched_param = &sch_p;
 	sess = wd_ecc_alloc_sess(&sp);
 	if (!sess)
 		fprintf(stderr, "failed to alloc ecc sess\n");

--- a/src/uadk_ecx.c
+++ b/src/uadk_ecx.c
@@ -73,6 +73,7 @@ static int reverse_bytes(unsigned char *to_buf, unsigned int size)
 static int x25519_init(EVP_PKEY_CTX *ctx)
 {
 	struct wd_ecc_sess_setup setup = {0};
+	struct sched_params params = {0};
 	struct ecx_ctx *x25519_ctx;
 	int ret;
 
@@ -91,7 +92,8 @@ static int x25519_init(EVP_PKEY_CTX *ctx)
 
 	setup.alg = "x25519";
 	setup.key_bits = X25519_KEYBITS;
-	setup.numa = uadk_e_ecc_get_numa_id();
+	params.numa_id = uadk_e_ecc_get_numa_id();
+	setup.sched_param = &params;
 	x25519_ctx->sess = wd_ecc_alloc_sess(&setup);
 	if (!x25519_ctx->sess) {
 		fprintf(stderr, "failed to alloc sess\n");
@@ -122,6 +124,7 @@ static void x25519_uninit(EVP_PKEY_CTX *ctx)
 static int x448_init(EVP_PKEY_CTX *ctx)
 {
 	struct wd_ecc_sess_setup setup = {0};
+	struct sched_params params = {0};
 	struct ecx_ctx *x448_ctx;
 	int ret;
 
@@ -140,7 +143,8 @@ static int x448_init(EVP_PKEY_CTX *ctx)
 	memset(x448_ctx, 0, sizeof(struct ecx_ctx));
 	setup.alg = "x448";
 	setup.key_bits = X448_KEYBITS;
-	setup.numa = uadk_e_ecc_get_numa_id();
+	params.numa_id = uadk_e_ecc_get_numa_id();
+	setup.sched_param = &params;
 	x448_ctx->sess = wd_ecc_alloc_sess(&setup);
 	if (!x448_ctx->sess) {
 		fprintf(stderr, "failed to alloc sess\n");

--- a/src/uadk_pkey.c
+++ b/src/uadk_pkey.c
@@ -62,12 +62,15 @@ struct ecc_res {
 
 static struct uadk_pkey_meth pkey_meth;
 
-static __u32 ecc_pick_next_ctx(handle_t sched_ctx, const void *req,
-			       const struct sched_key *key)
+static handle_t ecc_sched_init(handle_t h_sched_ctx, void *sched_param)
 {
-	const struct wd_ecc_req *ecc_req = req;
+	return (handle_t)0;
+}
 
-	if (ecc_req->cb)
+static __u32 ecc_pick_next_ctx(handle_t sched_ctx,
+		void *sched_key, const int sched_mode)
+{
+	if (sched_mode)
 		return CTX_ASYNC;
 	else
 		return CTX_SYNC;
@@ -130,6 +133,7 @@ struct ecc_res_config ecc_res_config = {
 		.sched_type = -1,
 		.wd_sched = {
 			.name = "ECC RR",
+			.sched_init = ecc_sched_init,
 			.pick_next_ctx = ecc_pick_next_ctx,
 			.poll_policy = ecc_poll_policy,
 			.h_sched_ctx = 0,
@@ -167,7 +171,7 @@ static int uadk_e_wd_ecc_env_init(struct uacce_dev *dev)
 	if (ret)
 		return ret;
 
-	ret = wd_ecc_env_init();
+	ret = wd_ecc_env_init(NULL);
 	if (ret)
 		return ret;
 

--- a/src/uadk_sm2.c
+++ b/src/uadk_sm2.c
@@ -46,11 +46,6 @@ struct sm2_ctx {
 	bool is_init;
 };
 
-struct ecc_sched {
-	int sched_type;
-	struct wd_sched wd_sched;
-};
-
 typedef struct uadk_ecc_sess {
 	handle_t sess;
 	struct wd_ecc_sess_setup setup;


### PR DESCRIPTION
Due to the modification of the scheduler, the initialization of
environment variables needs to be adapted to the customizable scheduler.

Signed-off-by: Longfang Liu <liulongfang@huawei.com>