### PR TITLE
fix sm4-cbf128 flag nit

### DIFF
--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -1032,7 +1032,7 @@ static int bind_v3_cipher(void)
 			  sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
 			  uadk_e_do_cipher, uadk_e_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(sm4_cfb128, 1, 16, 16, EVP_CIPH_OFB_MODE,
+	UADK_CIPHER_DESCR(sm4_cfb128, 1, 16, 16, EVP_CIPH_CFB_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
 			  uadk_e_do_cipher, uadk_e_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);


### PR DESCRIPTION
The alg sm-cbf128 matches the mode EVP_CIPH_CFB_MODE, not EVP_CIPH_OFB_MODE

	modified:   src/uadk_cipher.c

Signed-off-by: Dai Zhiwei <daizhiwei3@huawei.com>