### PR TITLE
ecc: cleanup the form of the return value

### DIFF
--- a/src/uadk_ecx.c
+++ b/src/uadk_ecx.c
@@ -399,7 +399,7 @@ static int x25519_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
 		goto uninit_iot;
 
 	ret = uadk_ecc_crypto(keygen_ctx->sess, &req, (void *)keygen_ctx->sess);
-	if (ret != 1)
+	if (!ret)
 		goto uninit_iot;
 
 	ret = ecx_keygen_set_pkey(pkey, keygen_ctx, &req, ecx_key);
@@ -457,7 +457,7 @@ static int x448_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
 		goto uninit_iot;
 
 	ret = uadk_ecc_crypto(keygen_ctx->sess, &req, (void *)keygen_ctx->sess);
-	if (ret != 1)
+	if (!ret)
 		goto uninit_iot;
 
 	ret = ecx_keygen_set_pkey(pkey, keygen_ctx, &req, ecx_key);
@@ -659,7 +659,7 @@ static int x25519_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
 		goto uninit_iot;
 
 	ret = uadk_ecc_crypto(derive_ctx->sess, &req, (void *)derive_ctx);
-	if (ret != 1)
+	if (!ret)
 		goto uninit_iot;
 
 	wd_ecxdh_get_out_params(req.dst, &s_key);
@@ -745,7 +745,7 @@ static int x448_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
 		goto uninit_iot;
 
 	ret = uadk_ecc_crypto(derive_ctx->sess, &req, (void *)derive_ctx);
-	if (ret != 1)
+	if (!ret)
 		goto uninit_iot;
 
 	wd_ecxdh_get_out_params(req.dst, &s_key);

--- a/src/uadk_pkey.c
+++ b/src/uadk_pkey.c
@@ -273,8 +273,7 @@ static void uadk_wd_ecc_uninit(void)
 	ecc_res.pid = 0;
 }
 
-int uadk_ecc_crypto(handle_t sess,
-		    struct wd_ecc_req *req, void *usr)
+int uadk_ecc_crypto(handle_t sess, struct wd_ecc_req *req, void *usr)
 {
 	struct uadk_e_cb_info cb_param;
 	struct async_op op;
@@ -314,7 +313,7 @@ int uadk_ecc_crypto(handle_t sess,
 	} else {
 		ret = wd_do_ecc_sync(sess, req);
 		if (ret < 0)
-			return ret;
+			return 0;
 	}
 	return 1;
 err:

--- a/src/uadk_sm2.c
+++ b/src/uadk_sm2.c
@@ -359,7 +359,7 @@ static int sign_bin_to_ber(EC_KEY *ec, struct wd_dtb *r, struct wd_dtb *s,
 	}
 
 	ret = ECDSA_SIG_set0(e_sig, br, bs);
-	if (ret != 1) {
+	if (!ret) {
 		fprintf(stderr, "failed to ECDSA_SIG_set0\n");
 		ret = -EINVAL;
 		goto free_s;
@@ -686,7 +686,7 @@ static int sm2_sign(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen,
 	}
 
 	ret = uadk_ecc_crypto(smctx->sess, &req, smctx);
-	if (ret != 1) {
+	if (!ret) {
 		fprintf(stderr, "failed to uadk_ecc_crypto, ret = %d\n", ret);
 		ret = UADK_DO_SOFT;
 		goto uninit_iot;
@@ -907,7 +907,7 @@ static int sm2_encrypt(EVP_PKEY_CTX *ctx,
 	}
 
 	ret = uadk_ecc_crypto(smctx->sess, &req, smctx);
-	if (ret != 1) {
+	if (!ret) {
 		ret = UADK_DO_SOFT;
 		fprintf(stderr, "failed to uadk_ecc_crypto, ret = %d\n", ret);
 		goto uninit_iot;
@@ -1061,7 +1061,7 @@ static int sm2_decrypt(EVP_PKEY_CTX *ctx,
 	}
 
 	ret = uadk_ecc_crypto(smctx->sess, &req, smctx);
-	if (ret != 1) {
+	if (!ret) {
 		ret = UADK_DO_SOFT;
 		fprintf(stderr, "failed to uadk_ecc_crypto, ret = %d\n", ret);
 		goto uninit_iot;


### PR DESCRIPTION
This patch includes:
1. Unified the return value form.
2. Remove redundant goto jumps.

Signed-off-by: Zhiqi Song <songzhiqi1@huawei.com>