### PR TITLE
engine: fix uadk engine compatibility issue

### DIFF
--- a/src/e_uadk.c
+++ b/src/e_uadk.c
@@ -239,54 +239,42 @@ static void engine_init_child_at_fork_handler(void)
 #ifdef KAE
 static void bind_fn_kae_alg(ENGINE *e)
 {
-	struct uacce_dev *dev;
+	int dev_num;
 
-	dev = wd_get_accel_dev("cipher");
-	if (dev) {
-		if (!(dev->flags & UACCE_DEV_SVA)) {
-			cipher_module_init();
-			if (!ENGINE_set_ciphers(e, sec_engine_ciphers))
-				fprintf(stderr, "uadk bind cipher failed\n");
-			else
-				uadk_cipher_nosva = 1;
-		}
-		free(dev);
+	dev_num = wd_get_nosva_dev_num("cipher");
+	if (dev_num > 0) {
+		cipher_module_init();
+		if (!ENGINE_set_ciphers(e, sec_engine_ciphers))
+			fprintf(stderr, "uadk bind cipher failed\n");
+		else
+			uadk_cipher_nosva = 1;
 	}
 
-	dev = wd_get_accel_dev("digest");
-	if (dev) {
-		if (!(dev->flags & UACCE_DEV_SVA)) {
-			digest_module_init();
-			if (!ENGINE_set_digests(e, sec_engine_digests))
-				fprintf(stderr, "uadk bind digest failed\n");
-			else
-				uadk_digest_nosva = 1;
-		}
-		free(dev);
+	dev_num = wd_get_nosva_dev_num("digest");
+	if (dev_num > 0) {
+		digest_module_init();
+		if (!ENGINE_set_digests(e, sec_engine_digests))
+			fprintf(stderr, "uadk bind digest failed\n");
+		else
+			uadk_digest_nosva = 1;
 	}
 
-	dev = wd_get_accel_dev("rsa");
-	if (dev) {
-		if (!(dev->flags & UACCE_DEV_SVA)) {
-			hpre_module_init();
-			if (!ENGINE_set_RSA(e, hpre_get_rsa_methods()))
-				fprintf(stderr, "uadk bind rsa failed\n");
-			else
-				uadk_rsa_nosva = 1;
-		}
-		free(dev);
+	dev_num = wd_get_nosva_dev_num("rsa");
+	if (dev_num > 0) {
+		hpre_module_init();
+		if (!ENGINE_set_RSA(e, hpre_get_rsa_methods()))
+			fprintf(stderr, "uadk bind rsa failed\n");
+		else
+			uadk_rsa_nosva = 1;
 	}
 
-	dev = wd_get_accel_dev("dh");
-	if (dev) {
-		if (!(dev->flags & UACCE_DEV_SVA)) {
-			hpre_module_dh_init();
-			if (!ENGINE_set_DH(e, hpre_get_dh_methods()))
-				fprintf(stderr, "uadk bind dh failed\n");
-			else
-				uadk_dh_nosva = 1;
-		}
-		free(dev);
+	dev_num = wd_get_nosva_dev_num("dh");
+	if (dev_num > 0) {
+		hpre_module_dh_init();
+		if (!ENGINE_set_DH(e, hpre_get_dh_methods()))
+			fprintf(stderr, "uadk bind dh failed\n");
+		else
+			uadk_dh_nosva = 1;
 	}
 }
 #endif

--- a/src/v1/uadk_v1.h
+++ b/src/v1/uadk_v1.h
@@ -35,4 +35,5 @@ extern void hpre_dh_destroy(void);
 
 extern int hpre_pkey_meths(ENGINE *e, EVP_PKEY_METHOD **pmeth,
 			   const int **pnids, int nid);
+extern int wd_get_nosva_dev_num(const char *algorithm);
 #endif

--- a/src/v1/wdmngr/wd_alg_queue.c
+++ b/src/v1/wdmngr/wd_alg_queue.c
@@ -74,3 +74,7 @@ void wd_free_queue(struct wd_queue *queue)
 	}
 }
 
+int wd_get_nosva_dev_num(const char *algorithm)
+{
+	return wd_get_available_dev_num(algorithm);
+}

--- a/src/v1/wdmngr/wd_alg_queue.h
+++ b/src/v1/wdmngr/wd_alg_queue.h
@@ -25,4 +25,6 @@
 struct wd_queue *wd_new_queue(int algtype);
 
 void wd_free_queue(struct wd_queue *queue);
+
+int wd_get_nosva_dev_num(const char *algorithm);
 #endif


### PR DESCRIPTION
When uadk use no sva mode, it should use wd_get_available_dev_num,
otherwise, it will not find old kernel's device path with attrs.

Signed-off-by: Wenkai Lin <linwenkai6@hisilicon.com>