### PR TITLE
cipher/rsa: fixup some code check warning

### DIFF
--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -890,7 +890,6 @@ static int uadk_e_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 	struct async_op op;
 	int ret;
 
-
 	priv->req.src = (unsigned char *)in;
 	priv->req.in_bytes = inlen;
 	priv->req.dst = out;

--- a/src/uadk_rsa.c
+++ b/src/uadk_rsa.c
@@ -1781,7 +1781,6 @@ exe_soft:
 
 static RSA_METHOD *uadk_e_get_rsa_sw_methods(void)
 {
-
 	/* meth: default rsa software method */
 	const RSA_METHOD *meth = RSA_PKCS1_OpenSSL();
 


### PR DESCRIPTION
1. Do not add blank lines on the start of a code block defined by braces.
2. Do not put two or more continuous blank lines inside function.

Signed-off-by: Kai Ye <yekai13@huawei.com>