### PR TITLE
engine: add the kae log feature

### DIFF
--- a/src/e_uadk.c
+++ b/src/e_uadk.c
@@ -205,6 +205,7 @@ static int uadk_destroy(ENGINE *e)
 		hpre_destroy();
 	if (uadk_dh_nosva)
 		hpre_dh_destroy();
+	kae_debug_close_log();
 #endif
 
 	if (uadk_cipher)
@@ -348,6 +349,7 @@ static int bind_fn(ENGINE *e, const char *id)
 	}
 
 #ifdef KAE
+	kae_debug_init_log();
 	bind_fn_kae_alg(e);
 
 	if (uadk_cipher_nosva || uadk_digest_nosva || uadk_rsa_nosva ||

--- a/src/v1/uadk_v1.h
+++ b/src/v1/uadk_v1.h
@@ -16,6 +16,7 @@
 #define UADK_V1_H
 #include "async/async_poll.h"
 #include "utils/engine_fork.h"
+#include "utils/engine_log.h"
 
 extern void sec_ciphers_free_ciphers(void);
 extern int cipher_module_init(void);


### PR DESCRIPTION
The original version of the kae engine supports the log system. So
need to be enabled the kae log feature at uadk_engine.

Signed-off-by: Kai Ye <yekai13@huawei.com>