### PR TITLE
cipher: fix segmentation fault for uadk_e_ctx_init

### DIFF
--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -846,14 +846,15 @@ static void uadk_e_ctx_init(EVP_CIPHER_CTX *ctx, struct cipher_priv_ctx *priv)
 	struct sched_params params = {0};
 	int ret;
 
+	priv->req.iv_bytes = EVP_CIPHER_CTX_iv_length(ctx);
+	priv->req.iv = priv->iv;
+
 	ret = uadk_e_init_cipher();
 	if (unlikely(!ret)) {
 		priv->switch_flag = UADK_DO_SOFT;
 		fprintf(stderr, "uadk failed to init cipher HW!\n");
+		return;
 	}
-
-	priv->req.iv_bytes = EVP_CIPHER_CTX_iv_length(ctx);
-	priv->req.iv = priv->iv;
 
 	/*
 	 * The internal RR scheduler used by environment variables,


### PR DESCRIPTION
if uadk_e_init_cipher failed, there is no need to
alloc cipher session, and alloc session will meet
a segmentation fault because sched_init is not
set by wd_cipher_init.

Signed-off-by: Wenkai Lin <linwenkai6@hisilicon.com>