### PR TITLE
cipher: sm4-ecb algorithm is deleted by mistake

### DIFF
--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -104,6 +104,7 @@ static int cipher_930_nids[] = {
 	NID_aes_128_xts,
 	NID_aes_256_xts,
 	NID_sm4_cbc,
+	NID_sm4_ecb,
 	NID_des_ede3_cbc,
 	NID_des_ede3_ecb,
 	NID_aes_128_cfb128,


### PR DESCRIPTION
Because sm4-ecb alg is deleted by mistake. So this alg
not be found in hardware V3.

Signed-off-by: Kai Ye <yekai13@huawei.com>