### PR TITLE
uadk-engine: change Copyright to 2022

### DIFF
--- a/src/e_uadk.c
+++ b/src/e_uadk.c
@@ -1,5 +1,6 @@
 /*
- * Copyright 2020-2021 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Linaro ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/uadk.h
+++ b/src/uadk.h
@@ -1,5 +1,6 @@
 /*
- * Copyright 2020-2021 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Linaro ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/uadk_async.c
+++ b/src/uadk_async.c
@@ -1,5 +1,6 @@
 /*
- * Copyright 2020-2021 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Linaro ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/uadk_async.h
+++ b/src/uadk_async.h
@@ -1,5 +1,6 @@
 /*
- * Copyright 2020-2021 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Linaro ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -1,5 +1,6 @@
 /*
- * Copyright 2020-2021 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Linaro ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/uadk_dh.c
+++ b/src/uadk_dh.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Huawei Technologies Co.,Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/uadk_digest.c
+++ b/src/uadk_digest.c
@@ -1,5 +1,6 @@
 /*
- * Copyright 2020-2021 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Linaro ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/uadk_ec.c
+++ b/src/uadk_ec.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Huawei Technologies Co.,Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/uadk_ecx.c
+++ b/src/uadk_ecx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Huawei Technologies Co.,Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/uadk_pkey.c
+++ b/src/uadk_pkey.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Huawei Technologies Co.,Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/uadk_pkey.h
+++ b/src/uadk_pkey.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Huawei Technologies Co.,Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/uadk_rsa.c
+++ b/src/uadk_rsa.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Huawei Technologies Co.,Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/uadk_sm2.c
+++ b/src/uadk_sm2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2020-2022 Huawei Technologies Co.,Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Change Copyright to 2022
Add Linaro Copyright as well

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>