### PR TITLE
cipher: optimize the process of ctx initialization

### DIFF
--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -850,6 +850,9 @@ static void uadk_e_ctx_init(EVP_CIPHER_CTX *ctx, struct cipher_priv_ctx *priv)
 	priv->req.iv_bytes = EVP_CIPHER_CTX_iv_length(ctx);
 	priv->req.iv = priv->iv;
 
+	if (priv->switch_flag == UADK_DO_SOFT)
+		return;
+
 	ret = uadk_e_init_cipher();
 	if (unlikely(!ret)) {
 		priv->switch_flag = UADK_DO_SOFT;


### PR DESCRIPTION
Optimize the process of ctx initialization as switching to soft work.
If the ctx resources of a thread are insufficient at the beginning, the
thread can't apply for resources again. Therefore, an flag checking is
required.

Signed-off-by: Kai Ye <yekai13@huawei.com>