### PR TITLE
engine: add receiving timeout count

### DIFF
--- a/src/uadk.h
+++ b/src/uadk.h
@@ -22,8 +22,9 @@
 #include <uadk/wd_sched.h>
 #include "uadk_utils.h"
 
-#define ARRAY_SIZE(x)	(sizeof(x) / sizeof((x)[0]))
-#define ENV_STRING_LEN	256
+#define ARRAY_SIZE(x)		(sizeof(x) / sizeof((x)[0]))
+#define ENV_STRING_LEN		256
+#define ENGINE_RECV_MAX_CNT	60000000
 
 enum {
 	KUNPENG920,

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -504,6 +504,7 @@ static int sched_single_poll_policy(handle_t h_sched_ctx,
 static int uadk_e_cipher_poll(void *ctx)
 {
 	struct cipher_priv_ctx *priv = (struct cipher_priv_ctx *) ctx;
+	__u64 rx_cnt = 0;
 	__u32 recv = 0;
 	/* Poll one packet currently */
 	int expt = 1;
@@ -520,9 +521,11 @@ static int uadk_e_cipher_poll(void *ctx)
 			return 0;
 		else if (ret < 0 && ret != -EAGAIN)
 			return ret;
-	} while (ret == -EAGAIN);
+	} while (ret == -EAGAIN && (rx_cnt++ < ENGINE_RECV_MAX_CNT));
 
-	return ret;
+	fprintf(stderr, "failed to recv msg: timeout!\n");
+
+	return -ETIMEDOUT;
 }
 
 static int uadk_e_cipher_env_poll(void *ctx)

--- a/src/uadk_dh.c
+++ b/src/uadk_dh.c
@@ -204,6 +204,7 @@ static __u32 dh_pick_next_ctx(handle_t sched_ctx,
 
 static int uadk_e_dh_poll(void *ctx)
 {
+	__u64 rx_cnt = 0;
 	__u32 recv = 0;
 	int expect = 1;
 	int idx = 1;
@@ -215,9 +216,11 @@ static int uadk_e_dh_poll(void *ctx)
 			return UADK_E_POLL_SUCCESS;
 		else if (ret < 0 && ret != -EAGAIN)
 			return ret;
-	} while (ret == -EAGAIN);
+	} while (ret == -EAGAIN && (rx_cnt++ < ENGINE_RECV_MAX_CNT));
 
-	return ret;
+	fprintf(stderr, "failed to recv msg: timeout!\n");
+
+	return -ETIMEDOUT;
 }
 
 static void uadk_e_dh_cb(void *req_t)

--- a/src/uadk_digest.c
+++ b/src/uadk_digest.c
@@ -332,6 +332,7 @@ static int sched_single_poll_policy(handle_t h_sched_ctx,
 
 static int uadk_e_digest_poll(void *ctx)
 {
+	__u64 rx_cnt = 0;
 	__u32 recv = 0;
 	int expt = 1;
 	int ret = 0;
@@ -342,9 +343,11 @@ static int uadk_e_digest_poll(void *ctx)
 			return 0;
 		else if (ret < 0 && ret != -EAGAIN)
 			return ret;
-	} while (ret == -EAGAIN);
+	} while (ret == -EAGAIN && (rx_cnt++ < ENGINE_RECV_MAX_CNT));
 
-	return ret;
+	fprintf(stderr, "failed to recv msg: timeout!\n");
+
+	return -ETIMEDOUT;
 }
 
 static int uadk_e_digest_env_poll(void *ctx)

--- a/src/uadk_pkey.c
+++ b/src/uadk_pkey.c
@@ -113,6 +113,7 @@ void uadk_ecc_cb(void *req_t)
 static int uadk_ecc_poll(void *ctx)
 {
 	unsigned int recv = 0;
+	__u64 rx_cnt = 0;
 	int expt = 1;
 	int ret;
 
@@ -122,9 +123,11 @@ static int uadk_ecc_poll(void *ctx)
 			return 0;
 		else if (ret < 0 && ret != -EAGAIN)
 			return ret;
-	} while (ret == -EAGAIN);
+	} while (ret == -EAGAIN && (rx_cnt++ < ENGINE_RECV_MAX_CNT));
 
-	return ret;
+	fprintf(stderr, "failed to recv msg: timeout!\n");
+
+	return -ETIMEDOUT;
 }
 
 /* make resource configure static */

--- a/src/uadk_rsa.c
+++ b/src/uadk_rsa.c
@@ -656,6 +656,7 @@ static int rsa_poll_policy(handle_t h_sched_ctx, __u32 expect, __u32 *count)
 
 static int uadk_e_rsa_poll(void *ctx)
 {
+	__u64 rx_cnt = 0;
 	__u32 recv = 0;
 	int expt = 1;
 	int ret;
@@ -666,9 +667,11 @@ static int uadk_e_rsa_poll(void *ctx)
 			return UADK_E_POLL_SUCCESS;
 		else if (ret < 0 && ret != -EAGAIN)
 			return ret;
-	} while (ret == -EAGAIN);
+	} while (ret == -EAGAIN && (rx_cnt++ < ENGINE_RECV_MAX_CNT));
 
-	return ret;
+	fprintf(stderr, "failed to recv msg: timeout!\n");
+
+	return -ETIMEDOUT;
 }
 
 static struct rsa_res_config rsa_res_config = {


### PR DESCRIPTION
Increase the count of packet receiving timeout as doing async
jobs. Prevents falling into an infinite loop.

Signed-off-by: Kai Ye <yekai13@huawei.com>