### PR TITLE
uadk_utils: fix x86 local build

### DIFF
--- a/src/uadk_utils.c
+++ b/src/uadk_utils.c
@@ -16,6 +16,8 @@
  */
 #include "uadk_utils.h"
 
+#if defined(__AARCH64_CMODEL_SMALL__) && __AARCH64_CMODEL_SMALL__
+
 #define  UADK_MEM_IMPROVE_THRESHOLD 1024
 
 static void *memcpy_large(void *dstpp, const void *srcpp, size_t len)
@@ -61,3 +63,12 @@ void *uadk_memcpy(void *dstpp, const void *srcpp, size_t len)
 	else
 		return memcpy(dstpp, srcpp, len);
 }
+
+#else
+
+void *uadk_memcpy(void *dstpp, const void *srcpp, size_t len)
+{
+	return memcpy(dstpp, srcpp, len);
+}
+
+#endif


### PR DESCRIPTION
On x86 local build:
autoreconf -i
./configure --libdir=/usr/local/lib/engines-1.1/
make -j4

uadk_utils.c: In function ‘uadk_memcpy’:
uadk_utils.c:23:2: error: unknown register name ‘q1’ in ‘asm’
 __asm__ __volatile__(
    ^
uadk_utils.c:23:2: error: unknown register name ‘q0’ in ‘asm’ uadk_utils.c:23:2: error: unknown register name ‘x14’ in ‘asm’ uadk_utils.c:23:2: error: unknown register name ‘x5’ in ‘asm’ uadk_utils.c:23:2: error: unknown register name ‘x4’ in ‘asm’ uadk_utils.c:23:2: error: unknown register name ‘x3’ in ‘asm’

With this patch, x86 build is OK

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>