### PR TITLE
Some bugfix and cleanup

### DIFF
--- a/src/e_uadk.c
+++ b/src/e_uadk.c
@@ -116,7 +116,7 @@ int uadk_e_is_env_enabled(const char *alg_name)
 	int i = 0;
 
 	while (i < len) {
-		if (strcmp(uadk_env_enabled[i].alg_name, alg_name))
+		if (!strcmp(uadk_env_enabled[i].alg_name, alg_name))
 			return uadk_env_enabled[i].env_enabled;
 		i++;
 	}
@@ -130,7 +130,7 @@ static void uadk_e_set_env_enabled(const char *alg_name, __u8 value)
 	int i = 0;
 
 	while (i < len) {
-		if (strcmp(uadk_env_enabled[i].alg_name, alg_name)) {
+		if (!strcmp(uadk_env_enabled[i].alg_name, alg_name)) {
 			uadk_env_enabled[i].env_enabled = value;
 			return;
 		}

--- a/src/e_uadk.c
+++ b/src/e_uadk.c
@@ -89,13 +89,11 @@ static const ENGINE_CMD_DEFN g_uadk_cmd_defns[] = {
 	}
 };
 
-__attribute__((constructor))
-static void uadk_constructor(void)
+static void __attribute__((constructor)) uadk_constructor(void)
 {
 }
 
-__attribute__((destructor))
-static void uadk_destructor(void)
+static void __attribute__((destructor)) uadk_destructor(void)
 {
 }
 

--- a/src/uadk.h
+++ b/src/uadk.h
@@ -27,8 +27,8 @@
 #define ENGINE_RECV_MAX_CNT	60000000
 
 enum {
-	KUNPENG920,
-	KUNPENG930,
+	HW_V2,
+	HW_V3,
 };
 
 extern const char *engine_uadk_id;

--- a/src/uadk.h
+++ b/src/uadk.h
@@ -18,9 +18,6 @@
 #ifndef UADK_H
 #define UADK_H
 #include <openssl/engine.h>
-#include <uadk/wd.h>
-#include <uadk/wd_sched.h>
-#include "uadk_utils.h"
 
 #define ARRAY_SIZE(x)		(sizeof(x) / sizeof((x)[0]))
 #define ENV_STRING_LEN		256

--- a/src/uadk_async.c
+++ b/src/uadk_async.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <sys/eventfd.h>
 #include <unistd.h>
+#include <openssl/async.h>
 #include "uadk.h"
 #include "uadk_async.h"
 

--- a/src/uadk_async.h
+++ b/src/uadk_async.h
@@ -19,8 +19,8 @@
 #define UADK_ASYNC_H
 
 #include <stdbool.h>
-#include <openssl/async.h>
 #include <semaphore.h>
+#include <openssl/async.h>
 
 #define ASYNC_QUEUE_TASK_NUM 1024
 

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -22,6 +22,7 @@
 #include <dlfcn.h>
 #include <openssl/engine.h>
 #include <uadk/wd_cipher.h>
+#include <uadk/wd_sched.h>
 #include "uadk.h"
 #include "uadk_async.h"
 

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -77,7 +77,7 @@ static int platform;
 
 #define SMALL_PACKET_OFFLOAD_THRESHOLD_DEFAULT 192
 
-static int cipher_920_nids[] = {
+static int cipher_hw_v2_nids[] = {
 	NID_aes_128_cbc,
 	NID_aes_192_cbc,
 	NID_aes_256_cbc,
@@ -93,7 +93,7 @@ static int cipher_920_nids[] = {
 	0,
 };
 
-static int cipher_930_nids[] = {
+static int cipher_hw_v3_nids[] = {
 	NID_aes_128_cbc,
 	NID_aes_192_cbc,
 	NID_aes_256_cbc,
@@ -342,9 +342,9 @@ static int uadk_get_accel_platform(char *alg_name)
 		return 0;
 
 	if (!strcmp(dev->api, "hisi_qm_v2"))
-		platform = KUNPENG920;
+		platform = HW_V2;
 	else
-		platform = KUNPENG930;
+		platform = HW_V3;
 	free(dev);
 
 	return 1;
@@ -358,12 +358,12 @@ static int uadk_e_engine_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
 	int size;
 	int i;
 
-	if (platform == KUNPENG920) {
-		size = (sizeof(cipher_920_nids) - 1) / sizeof(int);
-		cipher_nids = cipher_920_nids;
+	if (platform == HW_V2) {
+		size = (sizeof(cipher_hw_v2_nids) - 1) / sizeof(int);
+		cipher_nids = cipher_hw_v2_nids;
 	} else {
-		size = (sizeof(cipher_930_nids) - 1) / sizeof(int);
-		cipher_nids = cipher_930_nids;
+		size = (sizeof(cipher_hw_v3_nids) - 1) / sizeof(int);
+		cipher_nids = cipher_hw_v3_nids;
 	}
 
 	if (!cipher) {
@@ -1073,7 +1073,7 @@ int uadk_e_bind_cipher(ENGINE *e)
 	}
 
 	bind_v2_cipher();
-	if (platform > KUNPENG920)
+	if (platform > HW_V2)
 		bind_v3_cipher();
 
 	return ENGINE_set_ciphers(e, uadk_e_engine_ciphers);
@@ -1155,7 +1155,7 @@ void uadk_e_destroy_cipher(void)
 	pthread_spin_destroy(&engine.lock);
 
 	destroy_v2_cipher();
-	if (platform > KUNPENG920)
+	if (platform > HW_V2)
 		destroy_v3_cipher();
 }
 

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -480,13 +480,11 @@ static __u32 sched_single_pick_next_ctx(handle_t sched_ctx,
 	struct sched_params *key = (struct sched_params *)sched_key;
 
 	if (sched_mode) {
-		/* async */
 		if (key->type == WD_CIPHER_ENCRYPTION)
 			return CTX_ASYNC_ENC;
 		else
 			return CTX_ASYNC_DEC;
 	} else {
-		/* sync */
 		if (key->type == WD_CIPHER_ENCRYPTION)
 			return CTX_SYNC_ENC;
 		else
@@ -744,7 +742,7 @@ static void async_cb(struct wd_cipher_req *req, void *data)
 	}
 }
 
-/* increment counter (128-bit int) by c */
+/* Increment counter (128-bit int) by c */
 static void ctr_iv_inc(uint8_t *counter, __u32 c)
 {
 	uint32_t n = CTR_128BIT_COUNTER;

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -749,17 +749,18 @@ static void ctr_iv_inc(uint8_t *counter, __u32 c)
 {
 	uint32_t n = CTR_128BIT_COUNTER;
 	uint8_t *counter1 = counter;
+	__u32 c_value = c;
 
 	/*
 	 * Since the counter has been increased 1 by the hardware,
 	 * so the c need to  decrease 1.
 	 */
-	c = c - 1;
+	c_value -= 1;
 	do {
 		--n;
-		c += counter1[n];
-		counter1[n] = (uint8_t)c;
-		c >>= BYTE_BITS;
+		c_value += counter1[n];
+		counter1[n] = (uint8_t)c_value;
+		c_value >>= BYTE_BITS;
 	} while (n);
 }
 

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -516,11 +516,13 @@ static int uadk_e_cipher_poll(void *ctx)
 
 	do {
 		ret = wd_cipher_poll_ctx(idx, expt, &recv);
-		if (recv == expt)
+		if (!ret && recv == expt)
 			return 0;
-		else if (ret < 0 && ret != -EAGAIN)
-			return ret;
-	} while (ret == -EAGAIN && (rx_cnt++ < ENGINE_RECV_MAX_CNT));
+		else if (ret == -EAGAIN)
+			rx_cnt++;
+		else
+			return -1;
+	} while (rx_cnt < ENGINE_RECV_MAX_CNT);
 
 	fprintf(stderr, "failed to recv msg: timeout!\n");
 
@@ -539,7 +541,8 @@ static int uadk_e_cipher_env_poll(void *ctx)
 		ret = wd_cipher_poll(expt, &recv);
 		if (ret < 0 || recv == expt)
 			return ret;
-	} while (rx_cnt++ < ENGINE_RECV_MAX_CNT);
+		rx_cnt++;
+	} while (rx_cnt < ENGINE_RECV_MAX_CNT);
 
 	fprintf(stderr, "failed to poll msg: timeout!\n");
 

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -469,7 +469,6 @@ static handle_t sched_single_init(handle_t h_sched_ctx, void *sched_param)
 		return (handle_t)0;
 	}
 
-	skey->numa_id = param->numa_id;
 	skey->type = param->type;
 
 	return (handle_t)skey;
@@ -881,7 +880,8 @@ static void uadk_e_ctx_init(EVP_CIPHER_CTX *ctx, struct cipher_priv_ctx *priv)
 	if (ret)
 		params.type = 0;
 
-	params.numa_id = engine.numa_id;
+	/* Use the default numa parameters */
+	params.numa_id = -1;
 	priv->setup.sched_param = &params;
 	if (!priv->sess) {
 		priv->sess = wd_cipher_alloc_sess(&priv->setup);

--- a/src/uadk_dh.c
+++ b/src/uadk_dh.c
@@ -23,6 +23,7 @@
 #include <openssl/dh.h>
 #include <string.h>
 #include <uadk/wd_dh.h>
+#include <uadk/wd_sched.h>
 #include "uadk.h"
 #include "uadk_async.h"
 

--- a/src/uadk_dh.c
+++ b/src/uadk_dh.c
@@ -603,7 +603,7 @@ static int dh_fill_genkey_req(const BIGNUM *g, const BIGNUM *p,
 	if (!ag_bin)
 		return UADK_E_FAIL;
 
-	/* malloc a contiguous chunk of memory */
+	/* Malloc a contiguous chunk of memory */
 	apriv_key_bin =  OPENSSL_malloc(key_size * DH_PARAMS_CNT);
 	if (!apriv_key_bin)
 		goto free_ag;
@@ -615,7 +615,7 @@ static int dh_fill_genkey_req(const BIGNUM *g, const BIGNUM *p,
 	memset(ap_bin, 0, key_size);
 	memset(out_pri, 0, key_size);
 
-	/* construct data block of g */
+	/* Construct data block of g */
 	ret = dh_set_g(g, key_size, ag_bin, dh_sess);
 	if (!ret)
 		goto free_apriv;
@@ -623,7 +623,6 @@ static int dh_fill_genkey_req(const BIGNUM *g, const BIGNUM *p,
 	dh_sess->req.xbytes = BN_bn2bin(priv_key, apriv_key_bin);
 	dh_sess->req.pbytes = BN_bn2bin(p, ap_bin);
 	dh_sess->req.x_p = (void *)apriv_key_bin;
-	/* the output from uadk */
 	dh_sess->req.pri = out_pri;
 	dh_sess->req.pri_bytes = key_size;
 	dh_sess->req.op_type = WD_DH_PHASE1;

--- a/src/uadk_digest.c
+++ b/src/uadk_digest.c
@@ -71,7 +71,7 @@ static struct digest_engine engine;
 
 struct evp_md_ctx_st {
 	const EVP_MD *digest;
-	/* functional reference if 'digest' is ENGINE-provided */
+	/* Functional reference if 'digest' is ENGINE-provided */
 	ENGINE *engine;
 	unsigned long flags;
 	void *md_data;

--- a/src/uadk_digest.c
+++ b/src/uadk_digest.c
@@ -25,8 +25,10 @@
 #include <openssl/evp.h>
 #include <uadk/wd_cipher.h>
 #include <uadk/wd_digest.h>
+#include <uadk/wd_sched.h>
 #include "uadk.h"
 #include "uadk_async.h"
+#include "uadk_utils.h"
 
 #define UADK_DO_SOFT	(-0xE0)
 #define CTX_SYNC	0

--- a/src/uadk_digest.c
+++ b/src/uadk_digest.c
@@ -523,7 +523,8 @@ static int uadk_e_digest_init(EVP_MD_CTX *ctx)
 		return 0;
 	}
 
-	params.numa_id = engine.numa_id;
+	/* Use the default numa parameters */
+	params.numa_id = -1;
 	priv->setup.sched_param = &params;
 	priv->sess = wd_digest_alloc_sess(&priv->setup);
 	if (unlikely(!priv->sess))

--- a/src/uadk_digest.c
+++ b/src/uadk_digest.c
@@ -343,11 +343,13 @@ static int uadk_e_digest_poll(void *ctx)
 
 	do {
 		ret = wd_digest_poll_ctx(CTX_ASYNC, expt, &recv);
-		if (recv == expt)
+		if (!ret && recv == expt)
 			return 0;
-		else if (ret < 0 && ret != -EAGAIN)
-			return ret;
-	} while (ret == -EAGAIN && (rx_cnt++ < ENGINE_RECV_MAX_CNT));
+		else if (ret == -EAGAIN)
+			rx_cnt++;
+		else
+			return -1;
+	} while (rx_cnt < ENGINE_RECV_MAX_CNT);
 
 	fprintf(stderr, "failed to recv msg: timeout!\n");
 
@@ -366,7 +368,8 @@ static int uadk_e_digest_env_poll(void *ctx)
 		ret = wd_digest_poll(expt, &recv);
 		if (ret < 0 || recv == expt)
 			return ret;
-	} while (rx_cnt++ < ENGINE_RECV_MAX_CNT);
+		rx_cnt++;
+	} while (rx_cnt < ENGINE_RECV_MAX_CNT);
 
 	fprintf(stderr, "failed to poll msg: timeout!\n");
 

--- a/src/uadk_ec.c
+++ b/src/uadk_ec.c
@@ -72,14 +72,15 @@ static void init_dtb_param(void *dtb, char *start,
 			   __u32 dsz, __u32 bsz, __u32 num)
 {
 	struct wd_dtb *tmp = dtb;
+	char *buff = start;
 	int i = 0;
 
 	while (i++ < num) {
-		tmp->data = start;
+		tmp->data = buff;
 		tmp->dsize = dsz;
 		tmp->bsize = bsz;
 		tmp += 1;
-		start += bsz;
+		buff += bsz;
 	}
 }
 

--- a/src/uadk_ec.c
+++ b/src/uadk_ec.c
@@ -23,6 +23,7 @@
 #include <openssl/err.h>
 #include <openssl/ec.h>
 #include <uadk/wd_ecc.h>
+#include <uadk/wd_sched.h>
 #include "uadk_pkey.h"
 #include "uadk.h"
 

--- a/src/uadk_ecx.c
+++ b/src/uadk_ecx.c
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  */
-#include <errno.h>
 #include <string.h>
 #include <openssl/bn.h>
 #include <openssl/engine.h>
@@ -24,6 +23,7 @@
 #include <openssl/ec.h>
 #include <openssl/evp.h>
 #include <uadk/wd_ecc.h>
+#include <uadk/wd_sched.h>
 #include "uadk_pkey.h"
 #include "uadk.h"
 

--- a/src/uadk_pkey.c
+++ b/src/uadk_pkey.c
@@ -17,6 +17,7 @@
 #include <openssl/engine.h>
 #include <uadk/wd.h>
 #include <uadk/wd_ecc.h>
+#include <uadk/wd_sched.h>
 #include "uadk_async.h"
 #include "uadk.h"
 #include "uadk_pkey.h"
@@ -381,6 +382,7 @@ int uadk_ecc_set_private_key(handle_t sess, const EC_KEY *eckey)
 	const EC_GROUP *group;
 	struct wd_dtb prikey;
 	const BIGNUM *d;
+	size_t degree;
 	int buflen;
 	int ret;
 
@@ -396,7 +398,8 @@ int uadk_ecc_set_private_key(handle_t sess, const EC_KEY *eckey)
 		return -EINVAL;
 	}
 
-	buflen = BITS_TO_BYTES(EC_GROUP_get_degree(group));
+	degree = EC_GROUP_get_degree(group);
+	buflen = BITS_TO_BYTES(degree);
 	ecc_key = wd_ecc_get_key(sess);
 	prikey.data = (void *)bin;
 	prikey.dsize = BN_bn2binpad(d, bin, buflen);

--- a/src/uadk_pkey.c
+++ b/src/uadk_pkey.c
@@ -110,11 +110,13 @@ static int uadk_ecc_poll(void *ctx)
 
 	do {
 		ret = wd_ecc_poll_ctx(CTX_ASYNC, expt, &recv);
-		if (recv == expt)
+		if (!ret && recv == expt)
 			return 0;
-		else if (ret < 0 && ret != -EAGAIN)
-			return ret;
-	} while (ret == -EAGAIN && (rx_cnt++ < ENGINE_RECV_MAX_CNT));
+		else if (ret == -EAGAIN)
+			rx_cnt++;
+		else
+			return -1;
+	} while (rx_cnt < ENGINE_RECV_MAX_CNT);
 
 	fprintf(stderr, "failed to recv msg: timeout!\n");
 
@@ -153,7 +155,8 @@ static int uadk_e_ecc_env_poll(void *ctx)
 		ret = wd_ecc_poll(expt, &recv);
 		if (ret < 0 || recv == expt)
 			return ret;
-	} while (rx_cnt++ < ENGINE_RECV_MAX_CNT);
+		rx_cnt++;
+	} while (rx_cnt < ENGINE_RECV_MAX_CNT);
 
 	fprintf(stderr, "failed to poll msg: timeout!\n");
 

--- a/src/uadk_pkey.c
+++ b/src/uadk_pkey.c
@@ -44,7 +44,7 @@ struct ecc_res_config {
 	int numa_id;
 };
 
-/* ecc global hardware resource is saved here */
+/* ECC global hardware resource is saved here */
 struct ecc_res {
 	struct wd_ctx_config *ctx_res;
 	int pid;
@@ -123,7 +123,7 @@ static int uadk_ecc_poll(void *ctx)
 	return -ETIMEDOUT;
 }
 
-/* make resource configure static */
+/* Make resource configure static */
 struct ecc_res_config ecc_res_config = {
 	.sched = {
 		.sched_type = -1,
@@ -234,7 +234,7 @@ static int uadk_wd_ecc_init(struct ecc_res_config *config)
 	struct uacce_dev *dev;
 	int ret;
 
-	/* ctx is no difference for sm2/ecdsa/ecdh/x25519/x448 */
+	/* The ctx is no difference for sm2/ecdsa/ecdh/x25519/x448 */
 	dev = wd_get_accel_dev("ecdsa");
 	if (!dev)
 		return -ENOMEM;
@@ -396,8 +396,7 @@ int uadk_ecc_set_private_key(handle_t sess, const EC_KEY *eckey)
 		return -EINVAL;
 	}
 
-	/* pad and convert bits to bytes */
-	buflen = (EC_GROUP_get_degree(group) + 7) / 8;
+	buflen = BITS_TO_BYTES(EC_GROUP_get_degree(group));
 	ecc_key = wd_ecc_get_key(sess);
 	prikey.data = (void *)bin;
 	prikey.dsize = BN_bn2binpad(d, bin, buflen);

--- a/src/uadk_pkey.h
+++ b/src/uadk_pkey.h
@@ -26,7 +26,6 @@
 #define UADK_ECC_MAX_KEY_BITS		521
 #define UADK_ECC_MAX_KEY_BYTES		66
 #define UADK_ECC_CV_PARAM_NUM		6
-#define UADK_BITS_2_BYTES_SHIFT		3
 #define SM2_KEY_BYTES			32
 #define UADK_OCTET_STRING		4
 #define UADK_ECC_PUBKEY_PARAM_NUM	2
@@ -34,6 +33,11 @@
 #define UADK_ECDH_CV_NUM		8
 #define ENV_ENABLED			1
 #define UADK_E_INVALID			(-2)
+#define TRANS_BITS_BYTES_SHIFT		3
+#define ECC_POINT_SIZE(n)		((n) * 2)
+#define GET_MS_BYTE(n)			((n) >> 8)
+#define GET_LS_BYTE(n)			((n) & 0xFF)
+#define DGST_SHIFT_NUM(n)		(8 - ((n) & 0x7))
 
 struct uadk_pkey_meth {
 	EVP_PKEY_METHOD *sm2;

--- a/src/uadk_rsa.c
+++ b/src/uadk_rsa.c
@@ -881,7 +881,9 @@ static struct uadk_rsa_sess *rsa_get_eng_session(RSA *rsa, unsigned int bits,
 
 	rsa_sess->key_size = key_size;
 	rsa_sess->setup.key_bits = key_size << BIT_BYTES_SHIFT;
-	params.numa_id = g_rsa_res.numa_id;
+
+	/* Use the default numa parameters */
+	params.numa_id = -1;
 	rsa_sess->setup.sched_param = &params;
 	rsa_sess->setup.is_crt = is_crt;
 

--- a/src/uadk_rsa.c
+++ b/src/uadk_rsa.c
@@ -932,14 +932,14 @@ static int rsa_fill_prikey(RSA *rsa, struct uadk_rsa_sess *rsa_sess,
 			   struct rsa_prikey_param *pri,
 			   unsigned char *in_buf, unsigned char *to)
 {
-	struct wd_rsa_prikey *prikey;
-	struct wd_dtb *wd_dq;
-	struct wd_dtb *wd_dp;
-	struct wd_dtb *wd_q;
-	struct wd_dtb *wd_p;
-	struct wd_dtb *wd_qinv;
-	struct wd_dtb *wd_d;
-	struct wd_dtb *wd_n;
+	struct wd_rsa_prikey *prikey = NULL;
+	struct wd_dtb *wd_qinv = NULL;
+	struct wd_dtb *wd_dq = NULL;
+	struct wd_dtb *wd_dp = NULL;
+	struct wd_dtb *wd_q = NULL;
+	struct wd_dtb *wd_p = NULL;
+	struct wd_dtb *wd_d = NULL;
+	struct wd_dtb *wd_n = NULL;
 
 	if (!(rsa_sess->is_prikey_ready) && (pri->is_crt)) {
 		wd_rsa_get_prikey(rsa_sess->sess, &prikey);

--- a/src/uadk_sm2.c
+++ b/src/uadk_sm2.c
@@ -22,6 +22,7 @@
 #include <openssl/ossl_typ.h>
 #include <openssl/err.h>
 #include <uadk/wd_ecc.h>
+#include <uadk/wd_sched.h>
 #include "uadk.h"
 #include "uadk_pkey.h"
 
@@ -550,6 +551,7 @@ static size_t ec_field_size(const EC_GROUP *group)
 	BIGNUM *a = BN_new();
 	BIGNUM *b = BN_new();
 	size_t field_size = 0;
+	size_t p_bits;
 
 	if (p == NULL || a == NULL || b == NULL)
 		goto done;
@@ -557,7 +559,8 @@ static size_t ec_field_size(const EC_GROUP *group)
 	if (!EC_GROUP_get_curve(group, p, a, b, NULL))
 		goto done;
 
-	field_size = BITS_TO_BYTES(BN_num_bits(p));
+	p_bits = BN_num_bits(p);
+	field_size = BITS_TO_BYTES(p_bits);
 
 done:
 	BN_free(p);
@@ -598,7 +601,7 @@ static int sm2_ciphertext_size(const EC_KEY *key,
 	 * Integer and string are simple type; set constructed = 0, means
 	 * primitive and definite length encoding.
 	 */
-	sz = 2 * ASN1_object_size(0, field_size + 1, V_ASN1_INTEGER)
+	sz = ECC_POINT_SIZE(ASN1_object_size(0, field_size + 1, V_ASN1_INTEGER))
 		+ ASN1_object_size(0, md_size, V_ASN1_OCTET_STRING)
 		+ ASN1_object_size(0, msg_len, V_ASN1_OCTET_STRING);
 	*ct_size = ASN1_object_size(1, sz, V_ASN1_SEQUENCE);

--- a/test/sanity_test.sh
+++ b/test/sanity_test.sh
@@ -103,7 +103,7 @@ if [[ $algs =~ "RSA" ]]; then
 	openssl speed -elapsed -engine $engine_id -async_jobs 1 rsa4096
 fi
 
-#ecdsa only supported in Kunpeng930 or later
+#ecdsa only supported in HW_V3 or later
 if [[ $algs =~ "id-ecPublicKey" ]]; then
 	echo "testing ECDSA"
 	openssl speed -elapsed -engine $engine_id ecdsap224
@@ -116,21 +116,21 @@ if [[ $algs =~ "id-ecPublicKey" ]]; then
 	openssl speed -elapsed -engine $engine_id -async_jobs 1 ecdsap521
 fi
 
-#X25519 only supported in Kunpeng930 or later
+#X25519 only supported in HW_V3 or later
 if [[ $algs =~ "X25519" ]]; then
 	echo "testing X25519"
 	openssl speed -elapsed -engine $engine_id ecdhx25519
 	openssl speed -elapsed -engine $engine_id -async_jobs 1 ecdhx25519
 fi
 
-#X448 only supported in Kunpeng930 or later
+#X448 only supported in HW_V3 or later
 if [[ $algs =~ "X448" ]]; then
 	echo "testing X448"
 	openssl speed -elapsed -engine $engine_id ecdhx448
 	openssl speed -elapsed -engine $engine_id -async_jobs 1 ecdhx448
 fi
 
-#ecdh only supported in Kunpeng930 or later
+#ecdh only supported in HW_V3 or later
 if [[ $algs =~ "id-ecPublicKey" ]]; then
 	echo "testing ECDH"
 	openssl speed -elapsed -engine $engine_id ecdhp192


### PR DESCRIPTION
Hao Fang (1):
  uadk_engine: use HW_V2/HW_V3 to distinguish different hardware
    platforms.

Longfang Liu (1):
  uadk/engine: Update the numa parameter of the scheduler

Zhiqi Song (6):
  sm2: bugfix about segfault in sm2 ctrl function
  uadk_engine: bugfix side effects of right operand
  uadk_engine: cleanup static check warning of clangtidy tool
  uadk_engine: bugfix enable environment variable
  uadk_engine: cleanup magic number and comments
  uadk_engine: cleanup header file