### PR TITLE
Makefile: Using pkg-config to check dependent lib

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,7 @@
 ACLOCAL_AMFLAGS = -I m4
+
+if HAVE_CRYPTO
+if HAVE_WD
 SUBDIRS = src
+endif
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([openssl-uadk], [1.0])
+AC_INIT([openssl-uadk], [1.0.1])
 AC_CONFIG_SRCDIR([src/e_uadk.c])
 AM_INIT_AUTOMAKE([1.10 no-define])
 
@@ -16,6 +16,13 @@ AC_SUBST(enable_kae)
 AM_CONDITIONAL([WD_KAE], [test "$enable_kae" = "yes"])
 
 AC_CHECK_HEADERS([openssl/engine.h])
+
+PKG_CHECK_MODULES(WD, libwd libwd_crypto, [with_wd=yes], [with_wd=no])
+AM_CONDITIONAL(HAVE_WD, [test "$with_wd" != "no"])
+
+PKG_CHECK_MODULES(libcrypto, libcrypto < 3.0 libcrypto >= 1.1,
+		  [with_crypto=yes], [with_crypto=no])
+AM_CONDITIONAL(HAVE_CRYPTO, test "$with_crypto" != "no")
 
 AC_CONFIG_FILES([
 	Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,16 +1,13 @@
+VERSION = 1:0:1
 ACLOCAL_AMFLAGS = -I m4
-
-MAJOR = 1
-MINOR = 0
-REVISION = 0
-UADK_ENGINE_VERSION = -version-number ${MAJOR}:${MINOR}:${REVISION}
 
 lib_LTLIBRARIES=uadk_engine.la
 
 uadk_engine_la_SOURCES=uadk_utils.c e_uadk.c uadk_cipher.c uadk_digest.c uadk_async.c \
 		uadk_rsa.c uadk_sm2.c uadk_pkey.c uadk_dh.c uadk_ec.c uadk_ecx.c
-uadk_engine_la_LIBADD=-ldl -lwd -lwd_crypto -lpthread
-uadk_engine_la_LDFLAGS=-module $(UADK_ENGINE_VERSION)
+uadk_engine_la_LIBADD=-ldl $(WD_LIBS) -lpthread
+uadk_engine_la_LDFLAGS=-module -version-number $(VERSION)
+uadk_engine_la_CFLAGS=$(WD_CFLAGS)
 
 AUTOMAKE_OPTIONS = subdir-objects
 


### PR DESCRIPTION
Using pkg-config to get info of dependent library: libwd, libwd_crypto, libcrypto, which maybe installed to tmp folder.
Also check openssl:libcrypto version, only 1.1.x are supported.

For example uadk is installed to /tmp/build instead of /usr/local/lib

$ pkg-config libwd --libs
No package 'libwd' found

$ cd openssl-uadk
$ autoreconf
$ ./configure --prefix=/tmp/build
$ make
no library is generated.

$ export PKG_CONFIG_PATH=/tmp/build/lib/pkgconfig/ $ pkg-config libwd --libs
-L/tmp/build/lib -lwd
$ cd openssl-uadk
$ autoreconf
$ ./configure --prefix=/tmp/build
$ make
$ make install
$ ls /tmp/build/lib/uadk_engine.so

$ openssl engine -c /tmp/build/lib/uadk_engine.so
(/tmp/build/lib/uadk_engine.so) uadk hardware engine support Loaded: (uadk_engine) uadk hardware engine support

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>