### PR TITLE
uadk_engine: rename openssl-uadk to uadk_engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ OpenSSL engine for uadk
 
 - [Prerequisites](#prerequisites)
 - [Installation Instruction](#installation-instruction)
-	- [Build & Install OpenSSL](#build-&-install-openssl)
-	- [Build & Install UADK](#build-&-install-uadk)
-	- [Build & Install OpenSSL UADK engine](#build-&-install-openssl-uadk-engine)
+	- [Build and install OpenSSL](#build-and-install-openssl)
+	- [Build and install UADK](#build-and-install-uadk)
+	- [Build and install UADK engine](#build-and-install-uadk-engine)
 	- [Testing](#testing)
 - [Install libraries to the temp folder](#Install-libraries-to-the-temp-folder)
 - [Environment variable of uadk engin](#Environment-variable-of-uadk-engine)
@@ -20,7 +20,7 @@ Prerequisites
 Installation Instruction
 ========================
 
-Build & Install OpenSSL
+Build and install OpenSSL
 -----------------------
 
 ```
@@ -34,7 +34,7 @@ Build & Install OpenSSL
     openssl version
 ```
 
-Build & Install UADK
+Build and install UADK
 --------------------
 
 ```
@@ -49,11 +49,11 @@ Build & Install UADK
 * If get error:"cannot find -lnuma", please install the libnuma-dev
 * If get error:"fatal error: zlib.h: No such file or directory", please install zlib.
 
-Build & Install OpenSSL UADK Engine
+Build and install UADK Engine
 -----------------------------------
 ```
-    git clone https://github.com/Linaro/openssl-uadk.git
-    cd openssl-uadk
+    git clone https://github.com/Linaro/uadk_engine.git
+    cd uadk_engine
     autoreconf -i
     ./configure --libdir=/usr/local/lib/engines-1.1/ --enable-kae
     make
@@ -92,7 +92,7 @@ Install libraries to the temp folder
     $ pkg-config libwd --libs
     -L/tmp/build/lib -lwd
 
-    $ cd openssl-uadk
+    $ cd uadk_engine
     $ autoreconf
     $ ./configure --prefix=/tmp/build
     $ make; make install

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([openssl-uadk], [1.0.1])
+AC_INIT([uadk_engine], [1.0.1])
 AC_CONFIG_SRCDIR([src/e_uadk.c])
 AM_INIT_AUTOMAKE([1.10 no-define])
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -5,7 +5,7 @@
 
 Clone UADK from [Github](https://github.com/Linaro/uadk).
 
-Clone openssl-uadk from [Github](https://github.com/Linaro/openssl-uadk).
+Clone uadk_engine from [Github](https://github.com/Linaro/uadk_engine).
 
 ## License
 


### PR DESCRIPTION
Repo's name has changed to uadk_engine, so modify accordingly.

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>