### PR TITLE
Makefile: fix AM_CFLAGS not working for kae

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,7 +12,7 @@ uadk_engine_la_CFLAGS=$(WD_CFLAGS)
 AUTOMAKE_OPTIONS = subdir-objects
 
 if WD_KAE
-AM_CFLAGS = -DKAE
+uadk_engine_la_CFLAGS += -DKAE
 uadk_engine_la_SOURCES+=v1/alg/ciphers/sec_ciphers.c \
 		 v1/alg/ciphers/sec_ciphers_soft.c \
 		 v1/alg/ciphers/sec_ciphers_utils.c \


### PR DESCRIPTION
uadk_engine_la_cflags will override AM_CFLAGS,
so use uadk_engine_la_cflags to set DKAE flags.

Signed-off-by: Wenkai Lin <linwenkai6@hisilicon.com>