### PR TITLE
uadk_engine: release 1.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([uadk_engine], [1.0.1])
+AC_INIT([uadk_engine], [1.1])
 AC_CONFIG_SRCDIR([src/e_uadk.c])
 AM_INIT_AUTOMAKE([1.10 no-define])
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,5 +1,5 @@
 
-# UADK engine Release Pre v1.1 November 2022
+# UADK engine Release v1.1 December 2022
 
 ## New Features
 
@@ -41,5 +41,5 @@
 
 ## Working combination
 
-- UADK v2.3.28
+- UADK v2.4
 - OpenSSL 1.1.1f

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-VERSION = 1:0:1
+VERSION = 1:1
 ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES=uadk_engine.la


### PR DESCRIPTION
Release 1.1 in 2022.12
UAKD version is 2.4

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>