### PR TITLE
uadk: support openssl 3.0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,3 @@
 ACLOCAL_AMFLAGS = -I m4
 
-if HAVE_CRYPTO
-if HAVE_WD
 SUBDIRS = src
-endif
-endif

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ OpenSSL engine for uadk
 Prerequisites
 =============
 * CPU: aarch64
-* OpenSSL: 1.1.1f
+* OpenSSL: 1.1.1f or 3.0
 * libnuma
 * zlib
 
@@ -26,8 +26,11 @@ Build and install OpenSSL
 ```
     git clone https://github.com/openssl/openssl.git
     cd openssl
-    git checkout -b OpenSSL_1_1_1f OpenSSL_1_1_1f
-    ./config -Wl,-rpath=/usr/local/lib
+    // For openssl1.1.1f
+    git checkout -b opensssl1.1 OpenSSL_1_1_1f
+    // for openssl 3.0
+    git checkout -b openssl3.0 openssl-3.0.0
+    ./config
     make
     make test
     sudo make install
@@ -51,6 +54,7 @@ Build and install UADK
 
 Build and install UADK Engine
 -----------------------------------
+For openssl 1.1
 ```
     git clone https://github.com/Linaro/uadk_engine.git
     cd uadk_engine
@@ -60,6 +64,17 @@ Build and install UADK Engine
     sudo make install
 
     Option --enable-kae can be chosen to enable KAE for non-sva version
+```
+
+For openssl 3.0
+```
+    git clone https://github.com/Linaro/uadk_engine.git
+    cd uadk_engine
+    autoreconf -i
+    ./configure --libdir=/usr/local/lib/ossl-modules/
+    make
+    sudo make install
+
 ```
 
 Testing
@@ -93,12 +108,17 @@ Install libraries to the temp folder
     -L/tmp/build/lib -lwd
 
     $ cd uadk_engine
-    $ autoreconf
+    $ autoreconf -i
     $ ./configure --prefix=/tmp/build
     $ make; make install
 
+    // For openssl 1.1
     $ openssl engine -c /tmp/build/lib/uadk_engine.so
     $ ./test/sanity_test.sh /tmp/build/lib/uadk_engine.so
+
+    // For openssl 3.0
+    $ openssl speed -provider /tmp/build/lib/uadk_provider.so -provider default -evp md5
+    $ ./test/sanity_test.sh /tmp/build/lib/uadk_provider.so
 
 ```
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,5 @@
 AC_PREREQ([2.69])
 AC_INIT([uadk_engine], [1.1])
-AC_CONFIG_SRCDIR([src/e_uadk.c])
 AM_INIT_AUTOMAKE([1.10 no-define])
 
 AC_CONFIG_MACRO_DIR([m4])
@@ -15,14 +14,16 @@ AC_ARG_ENABLE(kae,
 AC_SUBST(enable_kae)
 AM_CONDITIONAL([WD_KAE], [test "$enable_kae" = "yes"])
 
-AC_CHECK_HEADERS([openssl/engine.h])
-
 PKG_CHECK_MODULES(WD, libwd libwd_crypto, [with_wd=yes], [with_wd=no])
 AM_CONDITIONAL(HAVE_WD, [test "$with_wd" != "no"])
 
 PKG_CHECK_MODULES(libcrypto, libcrypto < 3.0 libcrypto >= 1.1,
 		  [with_crypto=yes], [with_crypto=no])
 AM_CONDITIONAL(HAVE_CRYPTO, test "$with_crypto" != "no")
+
+PKG_CHECK_MODULES(libcrypto, libcrypto >= 3.0,
+		  [with_crypto3=yes], [with_crypto3=no])
+AM_CONDITIONAL(HAVE_CRYPTO3, test "$with_crypto3" != "no")
 
 AC_CONFIG_FILES([
 	Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,14 +1,23 @@
 VERSION = 1:1
 ACLOCAL_AMFLAGS = -I m4
 
+if HAVE_WD
+if HAVE_CRYPTO
 lib_LTLIBRARIES=uadk_engine.la
+endif #HAVE_CRYPTO
 
-uadk_engine_la_SOURCES=uadk_utils.c e_uadk.c uadk_cipher.c uadk_digest.c uadk_async.c \
-		uadk_rsa.c uadk_sm2.c uadk_pkey.c uadk_dh.c uadk_ec.c uadk_ecx.c
+if HAVE_CRYPTO3
+lib_LTLIBRARIES=uadk_provider.la
+endif #HAVE_CRYPTO3
+endif #HAVE_WD
+
+uadk_engine_la_SOURCES=uadk_utils.c uadk_engine_init.c uadk_cipher.c \
+		       uadk_digest.c uadk_async.c uadk_rsa.c uadk_sm2.c \
+		       uadk_pkey.c uadk_dh.c uadk_ec.c uadk_ecx.c
 uadk_engine_la_LIBADD=-ldl $(WD_LIBS) -lpthread
 uadk_engine_la_LDFLAGS=-module -version-number $(VERSION)
-uadk_engine_la_CFLAGS=$(WD_CFLAGS)
-
+uadk_engine_la_CFLAGS=$(WD_CFLAGS) $(libcrypto_CFLAGS)
+uadk_engine_la_CFLAGS+=-DCRYPTO
 AUTOMAKE_OPTIONS = subdir-objects
 
 if WD_KAE
@@ -40,3 +49,10 @@ uadk_engine_la_SOURCES+=v1/alg/ciphers/sec_ciphers.c \
 		 v1/async/async_poll.c \
 		 v1/async/async_task_queue.c
 endif #WD_KAE
+
+uadk_provider_la_SOURCES=uadk_prov_init.c uadk_digest.c uadk_async.c uadk_utils.c
+
+uadk_provider_la_LDFLAGS=-module -version-number $(VERSION)
+uadk_provider_la_LIBADD=$(WD_LIBS) -lpthread
+uadk_provider_la_CFLAGS=$(WD_CFLAGS) $(libcrypto_CFLAGS)
+uadk_provider_la_CFLAGS+=-DCRYPTO3

--- a/src/uadk.h
+++ b/src/uadk.h
@@ -39,11 +39,20 @@ int uadk_e_bind_dh(ENGINE *e);
 void uadk_e_destroy_dh(void);
 int uadk_e_bind_ecc(ENGINE *e);
 void uadk_e_destroy_ecc(void);
-int uadk_e_is_env_enabled(const char *alg_name);
-int uadk_e_set_env(const char *var_name, int numa_id);
 void uadk_e_ecc_lock_init(void);
 void uadk_e_rsa_lock_init(void);
 void uadk_e_dh_lock_init(void);
 void uadk_e_cipher_lock_init(void);
 void uadk_e_digest_lock_init(void);
+
+#ifdef CRYPTO3
+extern const OSSL_DISPATCH uadk_md5_functions[];
+extern const OSSL_DISPATCH uadk_sm3_functions[];
+extern const OSSL_DISPATCH uadk_sha1_functions[];
+extern const OSSL_DISPATCH uadk_sha224_functions[];
+extern const OSSL_DISPATCH uadk_sha256_functions[];
+extern const OSSL_DISPATCH uadk_sha384_functions[];
+extern const OSSL_DISPATCH uadk_sha512_functions[];
+#endif
+
 #endif

--- a/src/uadk_async.h
+++ b/src/uadk_async.h
@@ -63,6 +63,7 @@ struct async_poll_queue {
 	sem_t full_sem;
 	pthread_mutex_t async_task_mutex;
 	pthread_t thread_id;
+	bool init;
 };
 
 int async_setup_async_event_notification(struct async_op *op);

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -25,6 +25,7 @@
 #include <uadk/wd_sched.h>
 #include "uadk.h"
 #include "uadk_async.h"
+#include "uadk_utils.h"
 
 #define UADK_DO_SOFT         (-0xE0)
 #define CTX_SYNC_ENC		0

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -37,7 +37,6 @@
 #define CTR_MODE_LEN_SHIFT	4
 #define BYTE_BITS		8
 #define IV_LEN			16
-#define ENV_ENABLED		1
 #define MAX_KEY_LEN		64
 
 struct cipher_engine {
@@ -572,8 +571,7 @@ static int uadk_e_wd_cipher_init(struct uacce_dev *dev)
 
 	engine.numa_id = dev->numa_id;
 
-	ret = uadk_e_is_env_enabled("cipher");
-	if (ret == ENV_ENABLED)
+	if (uadk_e_is_env_enabled("cipher"))
 		return uadk_e_wd_cipher_env_init(dev);
 
 	memset(&engine.ctx_cfg, 0, sizeof(struct wd_ctx_config));
@@ -880,8 +878,7 @@ static void uadk_e_ctx_init(EVP_CIPHER_CTX *ctx, struct cipher_priv_ctx *priv)
 	 * encryption and decryption queues
 	 */
 	params.type = priv->req.op_type;
-	ret = uadk_e_is_env_enabled("cipher");
-	if (ret)
+	if (uadk_e_is_env_enabled("cipher"))
 		params.type = 0;
 
 	/* Use the default numa parameters */
@@ -1141,11 +1138,10 @@ static void destroy_v3_cipher(void)
 
 void uadk_e_destroy_cipher(void)
 {
-	int i, ret;
+	int i;
 
 	if (engine.pid == getpid()) {
-		ret = uadk_e_is_env_enabled("cipher");
-		if (ret == ENV_ENABLED) {
+		if (uadk_e_is_env_enabled("cipher")) {
 			wd_cipher_env_uninit();
 		} else {
 			wd_cipher_uninit();

--- a/src/uadk_dh.c
+++ b/src/uadk_dh.c
@@ -26,6 +26,7 @@
 #include <uadk/wd_sched.h>
 #include "uadk.h"
 #include "uadk_async.h"
+#include "uadk_utils.h"
 
 #define DH768BITS		768
 #define DH1024BITS		1024

--- a/src/uadk_dh.c
+++ b/src/uadk_dh.c
@@ -52,7 +52,6 @@
 #define UADK_E_POLL_SUCCESS	0
 #define UADK_E_POLL_FAIL	(-1)
 #define UADK_E_INIT_SUCCESS	0
-#define ENV_ENABLED		1
 
 static DH_METHOD *uadk_dh_method;
 
@@ -320,8 +319,7 @@ static int uadk_e_wd_dh_init(struct dh_res_config *config, struct uacce_dev *dev
 	int ret = 0;
 	int i;
 
-	ret = uadk_e_is_env_enabled("dh");
-	if (ret == ENV_ENABLED)
+	if (uadk_e_is_env_enabled("dh"))
 		return uadk_e_wd_dh_env_init(dev);
 
 	ctx_cfg = calloc(1, sizeof(struct wd_ctx_config));
@@ -408,11 +406,10 @@ err_unlock:
 static void uadk_e_wd_dh_uninit(void)
 {
 	struct wd_ctx_config *ctx_cfg = g_dh_res.ctx_res;
-	int i, ret;
+	int i;
 
 	if (g_dh_res.pid == getpid()) {
-		ret = uadk_e_is_env_enabled("dh");
-		if (ret == ENV_ENABLED) {
+		if (uadk_e_is_env_enabled("dh")) {
 			wd_dh_env_uninit();
 		} else {
 			wd_dh_uninit();

--- a/src/uadk_digest.c
+++ b/src/uadk_digest.c
@@ -41,7 +41,6 @@
 #define CTX_NUM		2
 #define DIGEST_DOING	1
 #define DIGEST_END	0
-#define ENV_ENABLED	1
 
 /* The max BD data length is 16M-512B */
 #define BUF_LEN      0xFFFE00
@@ -455,8 +454,7 @@ static int uadk_e_wd_digest_init(struct uacce_dev *dev)
 
 	engine.numa_id = dev->numa_id;
 
-	ret = uadk_e_is_env_enabled("digest");
-	if (ret == ENV_ENABLED)
+	if (uadk_e_is_env_enabled("digest"))
 		return uadk_e_wd_digest_env_init(dev);
 
 	memset(&engine.ctx_cfg, 0, sizeof(struct wd_ctx_config));
@@ -988,11 +986,10 @@ int uadk_e_bind_digest(ENGINE *e)
 
 void uadk_e_destroy_digest(void)
 {
-	int i, ret;
+	int i;
 
 	if (engine.pid == getpid()) {
-		ret = uadk_e_is_env_enabled("digest");
-		if (ret == ENV_ENABLED) {
+		if (uadk_e_is_env_enabled("digest")) {
 			wd_digest_env_uninit();
 		} else {
 			wd_digest_uninit();

--- a/src/uadk_engine_init.c
+++ b/src/uadk_engine_init.c
@@ -24,6 +24,7 @@
 #include <uadk/wd.h>
 #include "uadk.h"
 #include "uadk_async.h"
+#include "uadk_utils.h"
 #ifdef KAE
 #include "v1/uadk_v1.h"
 #endif
@@ -35,7 +36,6 @@
 #define UADK_CMD_ENABLE_ECC_ENV		(ENGINE_CMD_BASE + 4)
 
 /* Constants used when creating the ENGINE */
-const char *engine_uadk_id = "uadk_engine";
 static const char *engine_uadk_name = "uadk hardware engine support";
 
 static int uadk_cipher;
@@ -95,70 +95,6 @@ static void __attribute__((constructor)) uadk_constructor(void)
 
 static void __attribute__((destructor)) uadk_destructor(void)
 {
-}
-
-struct uadk_alg_env_enabled {
-	const char *alg_name;
-	__u8 env_enabled;
-};
-
-static struct uadk_alg_env_enabled uadk_env_enabled[] = {
-	{ "cipher", 0 },
-	{ "digest", 0 },
-	{ "rsa", 0 },
-	{ "dh", 0 },
-	{ "ecc", 0 }
-};
-
-int uadk_e_is_env_enabled(const char *alg_name)
-{
-	int len = ARRAY_SIZE(uadk_env_enabled);
-	int i = 0;
-
-	while (i < len) {
-		if (!strcmp(uadk_env_enabled[i].alg_name, alg_name))
-			return uadk_env_enabled[i].env_enabled;
-		i++;
-	}
-
-	return 0;
-}
-
-static void uadk_e_set_env_enabled(const char *alg_name, __u8 value)
-{
-	int len = ARRAY_SIZE(uadk_env_enabled);
-	int i = 0;
-
-	while (i < len) {
-		if (!strcmp(uadk_env_enabled[i].alg_name, alg_name)) {
-			uadk_env_enabled[i].env_enabled = value;
-			return;
-		}
-
-		i++;
-	}
-}
-
-int uadk_e_set_env(const char *var_name, int numa_id)
-{
-	char env_string[ENV_STRING_LEN] = {0};
-	const char *var_s;
-	int ret;
-
-	var_s = secure_getenv(var_name);
-	if (!var_s || !strlen(var_s)) {
-		/* uadk will request ctxs from device on specified numa node */
-		ret = snprintf(env_string, ENV_STRING_LEN, "%s%d%s%d",
-			       "sync:2@", numa_id,
-			       ",async:2@", numa_id);
-		if (ret < 0)
-			return ret;
-
-		ret = setenv(var_name, env_string, 1);
-		if (ret < 0)
-			return ret;
-	}
-	return 0;
 }
 
 static int uadk_engine_ctrl(ENGINE *e, int cmd, long i,

--- a/src/uadk_pkey.c
+++ b/src/uadk_pkey.c
@@ -18,9 +18,10 @@
 #include <uadk/wd.h>
 #include <uadk/wd_ecc.h>
 #include <uadk/wd_sched.h>
-#include "uadk_async.h"
 #include "uadk.h"
+#include "uadk_async.h"
 #include "uadk_pkey.h"
+#include "uadk_utils.h"
 
 #define ECC_MAX_DEV_NUM		16
 #define CTX_ASYNC		1

--- a/src/uadk_pkey.c
+++ b/src/uadk_pkey.c
@@ -243,8 +243,7 @@ static int uadk_wd_ecc_init(struct ecc_res_config *config)
 
 	config->numa_id = dev->numa_id;
 
-	ret = uadk_e_is_env_enabled("ecc");
-	if (ret)
+	if (uadk_e_is_env_enabled("ecc"))
 		ret = uadk_e_wd_ecc_env_init(dev);
 	else
 		ret = uadk_e_wd_ecc_general_init(dev, sched);
@@ -257,13 +256,12 @@ static int uadk_wd_ecc_init(struct ecc_res_config *config)
 static void uadk_wd_ecc_uninit(void)
 {
 	struct wd_ctx_config *ctx_cfg = ecc_res.ctx_res;
-	int i, ret;
+	int i;
 
 	if (ecc_res.pid != getpid())
 		return;
 
-	ret = uadk_e_is_env_enabled("ecc");
-	if (ret == ENV_ENABLED) {
+	if (uadk_e_is_env_enabled("ecc")) {
 		wd_ecc_env_uninit();
 	} else {
 		wd_ecc_uninit();

--- a/src/uadk_pkey.h
+++ b/src/uadk_pkey.h
@@ -31,7 +31,6 @@
 #define UADK_ECC_PUBKEY_PARAM_NUM	2
 #define UADK_ECC_PADDING		7
 #define UADK_ECDH_CV_NUM		8
-#define ENV_ENABLED			1
 #define UADK_E_INVALID			(-2)
 #define TRANS_BITS_BYTES_SHIFT		3
 #define ECC_POINT_SIZE(n)		((n) * 2)

--- a/src/uadk_prov_init.c
+++ b/src/uadk_prov_init.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022-2023 Huawei Technologies Co.,Ltd. All rights reserved.
+ * Copyright 2022-2023 Linaro ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/core_dispatch.h>
+#include <openssl/core_names.h>
+#include <openssl/crypto.h>
+
+#include "uadk.h"
+#include "uadk_async.h"
+
+struct p_uadk_ctx {
+	const OSSL_CORE_HANDLE *handle;
+	OSSL_LIB_CTX *libctx;
+};
+
+static const char UADK_DEFAULT_PROPERTIES[] = "provider=uadk";
+
+const OSSL_ALGORITHM uadk_prov_digests[] = {
+	{ OSSL_DIGEST_NAME_MD5, UADK_DEFAULT_PROPERTIES,
+	  uadk_md5_functions, "uadk_provider md5" },
+	{ OSSL_DIGEST_NAME_SM3, UADK_DEFAULT_PROPERTIES,
+	  uadk_sm3_functions, "uadk_provider sm3" },
+	{ OSSL_DIGEST_NAME_SHA1, UADK_DEFAULT_PROPERTIES,
+	  uadk_sha1_functions, "uadk_provider sha1" },
+	{ OSSL_DIGEST_NAME_SHA2_224, UADK_DEFAULT_PROPERTIES,
+	  uadk_sha224_functions, "uadk_provider sha2-224" },
+	{ OSSL_DIGEST_NAME_SHA2_256, UADK_DEFAULT_PROPERTIES,
+	  uadk_sha256_functions, "uadk_provider sha2-256" },
+	{ OSSL_DIGEST_NAME_SHA2_384, UADK_DEFAULT_PROPERTIES,
+	  uadk_sha384_functions, "uadk_provider sha2-384" },
+	{ OSSL_DIGEST_NAME_SHA2_512, UADK_DEFAULT_PROPERTIES,
+	  uadk_sha512_functions, "uadk_provider sha2-512" },
+	{ NULL, NULL, NULL }
+};
+
+
+static OSSL_FUNC_provider_query_operation_fn p_prov_query;
+static OSSL_FUNC_provider_teardown_fn p_teardown;
+
+static const OSSL_ALGORITHM *p_prov_query(void *provctx, int operation_id,
+					  int *no_cache)
+{
+	*no_cache = 0;
+
+	switch (operation_id) {
+	case OSSL_OP_DIGEST:
+		return uadk_prov_digests;
+	}
+	return NULL;
+}
+
+static const OSSL_DISPATCH p_test_table[] = {
+	{ OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))p_prov_query },
+	{ OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))p_teardown },
+	{ 0, NULL }
+};
+
+static void provider_init_child_at_fork_handler(void)
+{
+	int ret;
+
+	ret = async_module_init();
+	if (!ret)
+		fprintf(stderr, "async_module_init fail!\n");
+}
+
+int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
+		       const OSSL_DISPATCH *oin,
+		       const OSSL_DISPATCH **out,
+		       void **provctx)
+{
+	struct p_uadk_ctx *ctx;
+	int ret;
+
+	ctx = OPENSSL_zalloc(sizeof(*ctx));
+	if (ctx == NULL)
+		return 0;
+
+	ret = async_module_init();
+	if (!ret)
+		fprintf(stderr, "async_module_init fail!\n");
+	pthread_atfork(NULL, NULL, provider_init_child_at_fork_handler);
+
+	*provctx = (void *)ctx;
+	*out = p_test_table;
+	return 1;
+}
+
+static void p_teardown(void *provctx)
+{
+	struct p_uadk_ctx *ctx = (struct p_uadk_ctx *)provctx;
+
+	OPENSSL_free(ctx);
+
+}

--- a/src/uadk_rsa.c
+++ b/src/uadk_rsa.c
@@ -21,8 +21,9 @@
 #include <openssl/rsa.h>
 #include <uadk/wd_rsa.h>
 #include <uadk/wd_sched.h>
-#include "uadk_async.h"
 #include "uadk.h"
+#include "uadk_async.h"
+#include "uadk_utils.h"
 
 #define UN_SET				0
 #define IS_SET				1

--- a/src/uadk_rsa.c
+++ b/src/uadk_rsa.c
@@ -53,7 +53,6 @@
 #define UADK_E_POLL_FAIL		(-1)
 #define UADK_E_INIT_SUCCESS		0
 #define CHECK_PADDING_FAIL		(-1)
-#define ENV_ENABLED			1
 #define PRIME_RETRY_COUNT		4
 #define GENCB_NEXT			2
 #define GENCB_RETRY			3
@@ -740,8 +739,7 @@ static int uadk_e_wd_rsa_init(struct rsa_res_config *config,
 	int ret;
 	int i;
 
-	ret = uadk_e_is_env_enabled("rsa");
-	if (ret == ENV_ENABLED)
+	if (uadk_e_is_env_enabled("rsa"))
 		return uadk_e_wd_rsa_env_init(dev);
 
 	ctx_cfg = calloc(1, sizeof(struct wd_ctx_config));
@@ -829,11 +827,10 @@ err_unlock:
 static void uadk_e_rsa_uninit(void)
 {
 	struct wd_ctx_config *ctx_cfg = g_rsa_res.ctx_res;
-	int i, ret;
+	int i;
 
 	if (g_rsa_res.pid == getpid()) {
-		ret = uadk_e_is_env_enabled("rsa");
-		if (ret == ENV_ENABLED) {
+		if (uadk_e_is_env_enabled("rsa")) {
 			wd_rsa_env_uninit();
 		} else {
 			wd_rsa_uninit();

--- a/src/uadk_utils.c
+++ b/src/uadk_utils.c
@@ -14,7 +14,76 @@
  * limitations under the License.
  *
  */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include "uadk.h"
 #include "uadk_utils.h"
+
+const char *engine_uadk_id = "uadk_engine";
+
+struct uadk_alg_env_enabled {
+	const char *alg_name;
+	unsigned int env_enabled;
+};
+
+static struct uadk_alg_env_enabled uadk_env_enabled[] = {
+	{ "cipher", 0 },
+	{ "digest", 0 },
+	{ "rsa", 0 },
+	{ "dh", 0 },
+	{ "ecc", 0 }
+};
+
+int uadk_e_is_env_enabled(const char *alg_name)
+{
+	int len = ARRAY_SIZE(uadk_env_enabled);
+	int i = 0;
+
+	while (i < len) {
+		if (!strcmp(uadk_env_enabled[i].alg_name, alg_name))
+			return uadk_env_enabled[i].env_enabled;
+		i++;
+	}
+
+	return 0;
+}
+
+void uadk_e_set_env_enabled(const char *alg_name, unsigned int value)
+{
+	int len = ARRAY_SIZE(uadk_env_enabled);
+	int i = 0;
+
+	while (i < len) {
+		if (!strcmp(uadk_env_enabled[i].alg_name, alg_name)) {
+			uadk_env_enabled[i].env_enabled = value;
+			return;
+		}
+
+		i++;
+	}
+}
+
+int uadk_e_set_env(const char *var_name, int numa_id)
+{
+	char env_string[ENV_STRING_LEN] = {0};
+	const char *var_s;
+	int ret;
+
+	var_s = secure_getenv(var_name);
+	if (!var_s || !strlen(var_s)) {
+		/* uadk will request ctxs from device on specified numa node */
+		ret = snprintf(env_string, ENV_STRING_LEN, "%s%d%s%d",
+			       "sync:2@", numa_id,
+			       ",async:2@", numa_id);
+		if (ret < 0)
+			return ret;
+
+		ret = setenv(var_name, env_string, 1);
+		if (ret < 0)
+			return ret;
+	}
+	return 0;
+}
 
 #if defined(__AARCH64_CMODEL_SMALL__) && __AARCH64_CMODEL_SMALL__
 

--- a/src/uadk_utils.c
+++ b/src/uadk_utils.c
@@ -34,10 +34,27 @@ static struct uadk_alg_env_enabled uadk_env_enabled[] = {
 	{ "ecc", 0 }
 };
 
-int uadk_e_is_env_enabled(const char *alg_name)
+bool uadk_e_is_env_enabled(const char *alg_name)
 {
 	int len = ARRAY_SIZE(uadk_env_enabled);
+	char *var_name = NULL;
+	char *var_s;
 	int i = 0;
+
+	if (strcmp(alg_name, "digest") == 0)
+		var_name = "WD_DIGEST_CTX_NUM";
+	if (strcmp(alg_name, "cipher") == 0)
+		var_name = "WD_CIPHER_CTX_NUM";
+	if (strcmp(alg_name, "rsa") == 0)
+		var_name = "WD_RSA_CTX_NUM";
+	if (strcmp(alg_name, "dh") == 0)
+		var_name = "WD_DH_CTX_NUM";
+	if (strcmp(alg_name, "ecc") == 0)
+		var_name = "WD_ECC_CTX_NUM";
+
+	var_s = secure_getenv(var_name);
+	if (var_s)
+		return true;
 
 	while (i < len) {
 		if (!strcmp(uadk_env_enabled[i].alg_name, alg_name))
@@ -45,7 +62,7 @@ int uadk_e_is_env_enabled(const char *alg_name)
 		i++;
 	}
 
-	return 0;
+	return false;
 }
 
 void uadk_e_set_env_enabled(const char *alg_name, unsigned int value)

--- a/src/uadk_utils.h
+++ b/src/uadk_utils.h
@@ -21,4 +21,7 @@
 #include <string.h>
 
 void *uadk_memcpy(void *dstpp, const void *srcpp, size_t len);
+int uadk_e_is_env_enabled(const char *alg_name);
+void uadk_e_set_env_enabled(const char *alg_name, unsigned int value);
+int uadk_e_set_env(const char *var_name, int numa_id);
 #endif

--- a/src/uadk_utils.h
+++ b/src/uadk_utils.h
@@ -18,10 +18,11 @@
 #define UADK_UTILS
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 
 void *uadk_memcpy(void *dstpp, const void *srcpp, size_t len);
-int uadk_e_is_env_enabled(const char *alg_name);
+bool uadk_e_is_env_enabled(const char *alg_name);
 void uadk_e_set_env_enabled(const char *alg_name, unsigned int value);
 int uadk_e_set_env(const char *var_name, int numa_id);
 #endif

--- a/test/sanity_test.sh
+++ b/test/sanity_test.sh
@@ -2,14 +2,50 @@
 
 sudo chmod 666 /dev/hisi_*
 
-if [ ! -n "$1" ]; then
-	engine_id=uadk_engine
-else
-	engine_id=$1
+
+version=$(openssl version)
+echo $version
+if [[ $version =~ "3.0" ]]; then
+	echo "openssl 3.0"
+	if [ ! -n "$1" ]; then
+		engine_id=uadk_provider
+	else
+		engine_id=$1
+	fi
+
+	digest_algs=$(openssl  list -provider uadk_provider -digest-algorithms)
 fi
 
-algs=$(openssl engine -c $engine_id)
-echo $algs
+if [[ $digest_algs =~ "uadk_provider" ]]; then
+	echo "uadk_provider testing digest"
+	openssl speed -provider $engine_id -provider default -evp md5
+	openssl speed -provider $engine_id -provider default -evp sm3
+	openssl speed -provider $engine_id -provider default -evp sha1
+	openssl speed -provider $engine_id -provider default -evp sha2-224
+	openssl speed -provider $engine_id -provider default -evp sha2-256
+	openssl speed -provider $engine_id -provider default -evp sha2-384
+	openssl speed -provider $engine_id -provider default -evp sha2-512
+
+	openssl speed -provider $engine_id -provider default -async_jobs 1 -evp md5
+	openssl speed -provider $engine_id -provider default -async_jobs 1 -evp sm3
+	openssl speed -provider $engine_id -provider default -async_jobs 1 -evp sha1
+	openssl speed -provider $engine_id -provider default -async_jobs 1 -evp sha2-224
+	openssl speed -provider $engine_id -provider default -async_jobs 1 -evp sha2-256
+	openssl speed -provider $engine_id -provider default -async_jobs 1 -evp sha2-384
+	openssl speed -provider $engine_id -provider default -async_jobs 1 -evp sha2-512
+fi
+
+if [[ $version =~ "1.1.1" ]]; then
+	echo "openssl 1.1.1"
+	if [ ! -n "$1" ]; then
+		engine_id=uadk_engine
+	else
+		engine_id=$1
+	fi
+
+	algs=$(openssl engine -c $engine_id)
+	echo $algs
+fi
 
 #digest
 if [[ $algs =~ "MD5" ]]; then


### PR DESCRIPTION
Openssl3.0 provoder will be built when libcrypto >= 3.0

First step to support digest

Test with
openssl speed -provider xx/uadk_provider.so -provider default -evp md5 openssl speed -provider xx/uadk_provider.so -provider default -evp sm3 openssl speed -provider xx/uadk_provider.so -provider default -evp sha1 openssl speed -provider xx/uadk_provider.so -provider default -evp sha3-224 openssl speed -provider xx/uadk_provider.so -provider default -evp sha3-256 openssl speed -provider xx/uadk_provider.so -provider default -evp sha3-384 openssl speed -provider xx/uadk_provider.so -provider default -evp sha3-512

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>