### PR TITLE
cipher: fix double free error, set key error and async hardware computing error

### DIFF
--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -927,6 +927,14 @@ static int uadk_e_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 		if (!ret)
 			goto sync_err;
 	} else {
+		/*
+		 * If the length of the input data
+		 * does not reach to hardware computing threshold,
+		 * directly switch to soft cipher.
+		 */
+		if (priv->req.in_bytes <= priv->switch_threshold)
+			goto sync_err;
+
 		ret = do_cipher_async(priv, &op);
 		if (!ret)
 			goto out_notify;

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -878,6 +878,7 @@ static void uadk_e_ctx_init(EVP_CIPHER_CTX *ctx, struct cipher_priv_ctx *priv)
 	ret = wd_cipher_set_key(priv->sess, priv->key, EVP_CIPHER_CTX_key_length(ctx));
 	if (ret) {
 		wd_cipher_free_sess(priv->sess);
+		priv->sess = 0;
 		fprintf(stderr, "uadk failed to set key!\n");
 	}
 }


### PR DESCRIPTION
cipher: fix double free error
When wd_cipher_set_key() failed, after the handle is released, the handle should be set to 0 to avoid reusing.

cipher: fix set key error
Initialize the algorithm type again to prevent the algorithm type from being changed.

cipher: fix async hardware computing error
If the length of the input data does not reach to hardware computing threshold, directly switch to soft cipher.


