### PR TITLE
uadk_prov_cipher: fix padding

### DIFF
--- a/src/uadk_async.c
+++ b/src/uadk_async.c
@@ -112,7 +112,7 @@ int async_clear_async_event_notification(void)
 	return 1;
 }
 
-static void async_poll_task_free(void)
+void async_poll_task_free(void)
 {
 	int error;
 	struct async_poll_task *task;
@@ -381,8 +381,6 @@ int async_module_init(void)
 		goto err;
 
 	poll_queue.thread_id = thread_id;
-	OPENSSL_atexit(async_poll_task_free);
-
 	return 1;
 
 err:

--- a/src/uadk_async.h
+++ b/src/uadk_async.h
@@ -78,4 +78,5 @@ int async_module_init(void);
 int async_wake_job(ASYNC_JOB *job);
 void async_free_poll_task(int id, bool is_cb);
 int async_get_free_task(int *id);
+void async_poll_task_free(void);
 #endif

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -1024,7 +1024,7 @@ static int bind_v2_cipher(void)
 			  sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
 			  uadk_e_do_cipher, uadk_e_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(sm4_ecb, 16, 16, 16, EVP_CIPH_ECB_MODE,
+	UADK_CIPHER_DESCR(sm4_ecb, 16, 16, 0, EVP_CIPH_ECB_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
 			  uadk_e_do_cipher, uadk_e_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);

--- a/src/uadk_engine_init.c
+++ b/src/uadk_engine_init.c
@@ -220,6 +220,8 @@ static int uadk_destroy(ENGINE *e)
 	if (uadk_dh)
 		uadk_e_destroy_dh();
 
+	async_poll_task_free();
+
 	pthread_mutex_lock(&uadk_engine_mutex);
 	uadk_inited = 0;
 	pthread_mutex_unlock(&uadk_engine_mutex);

--- a/src/uadk_prov_cipher.c
+++ b/src/uadk_prov_cipher.c
@@ -143,12 +143,6 @@ static int uadk_fetch_sw_cipher(struct cipher_priv_ctx *priv)
 	case NID_aes_256_ecb:
 		priv->sw_cipher = EVP_CIPHER_fetch(NULL, "AES-256-ECB", "provider=default");
 		break;
-	case NID_aes_128_xts:
-		priv->sw_cipher = EVP_CIPHER_fetch(NULL, "AES-128-XTS", "provider=default");
-		break;
-	case NID_aes_256_xts:
-		priv->sw_cipher = EVP_CIPHER_fetch(NULL, "AES-256-XTS", "provider=default");
-		break;
 	case NID_sm4_cbc:
 		priv->sw_cipher = EVP_CIPHER_fetch(NULL, "SM4-CBC", "provider=default");
 		break;

--- a/src/uadk_prov_cipher.c
+++ b/src/uadk_prov_cipher.c
@@ -616,6 +616,17 @@ static int uadk_prov_cipher_set_ctx_params(void *vctx, const OSSL_PARAM params[]
 	if (params == NULL)
 		return 1;
 
+	p = OSSL_PARAM_locate_const(params, OSSL_CIPHER_PARAM_PADDING);
+	if (p != NULL) {
+		unsigned int pad;
+
+		if (!OSSL_PARAM_get_uint(p, &pad)) {
+			ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_GET_PARAMETER);
+			return 0;
+		}
+		EVP_CIPHER_CTX_set_padding(priv->sw_ctx, pad);
+	}
+
 	p = OSSL_PARAM_locate_const(params, OSSL_CIPHER_PARAM_KEYLEN);
 	if (p != NULL) {
 		size_t keylen;

--- a/src/uadk_prov_init.c
+++ b/src/uadk_prov_init.c
@@ -115,6 +115,7 @@ static void p_teardown(void *provctx)
 	uadk_prov_destroy_cipher();
 	OPENSSL_free(ctx);
 	OSSL_PROVIDER_unload(prov);
+	async_poll_task_free();
 }
 
 static const OSSL_DISPATCH p_test_table[] = {


### PR DESCRIPTION
Unlike openssl 1.1, openssl 3.0 requires "It is the responsibility of the cipher implementation to handle input lengths that are no multiples of the block length" [1]

Add padding handling via referring
providers/implementations/ciphers/ciphercommon.c

Additionally, the patch finds that using software and hardware ciphers does not work properly if alternating between the two. If using hardware, it is necessary to keep using hardware, and vice versa.

[1] https://www.openssl.org/docs/manmaster/man7/provider-cipher.html