### PR TITLE
Working provider load and a bug fix for sm4-ecb

### DIFF
--- a/src/uadk_prov_cipher.c
+++ b/src/uadk_prov_cipher.c
@@ -801,7 +801,7 @@ UADK_CIPHER_DESCR(aes_256_ecb, 16, 32, 0, 0, NID_aes_256_ecb, ecb(aes), EVP_CIPH
 UADK_CIPHER_DESCR(aes_128_xts, 1, 32, 16, 0, NID_aes_128_xts, xts(aes), EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV);
 UADK_CIPHER_DESCR(aes_256_xts, 1, 64, 16, 0, NID_aes_256_xts, xts(aes), EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV);
 UADK_CIPHER_DESCR(sm4_cbc, 16, 16, 16, 0, NID_sm4_cbc, cbc(sm4), EVP_CIPH_CBC_MODE);
-UADK_CIPHER_DESCR(sm4_ecb, 16, 16, 16, 0, NID_sm4_ecb, ecb(sm4), EVP_CIPH_ECB_MODE);
+UADK_CIPHER_DESCR(sm4_ecb, 16, 16, 0, 0, NID_sm4_ecb, ecb(sm4), EVP_CIPH_ECB_MODE);
 UADK_CIPHER_DESCR(des_ede3_cbc, 8, 24, 8, 0, NID_des_ede3_cbc, cbc(des), EVP_CIPH_CBC_MODE);
 UADK_CIPHER_DESCR(des_ede3_ecb, 8, 24, 0, 0, NID_des_ede3_ecb, ecb(des), EVP_CIPH_ECB_MODE);
 


### PR DESCRIPTION
commit d88411ccccb4df249ba196860f3f1cba090398bd (HEAD -> working_provider_load, guodong/working_provider_load)
Author: Guodong Xu <guodong.xu@linaro.org>
Date:   Mon Sep 4 09:45:05 2023 +0800

    uadk_provider: load default provider into Global library context
    
    Implementations in default provider are required in some cases.
    For example when the package size is small.
    
    In current design, we load default provider into Global library context,
    aka. NULL.
    
    Signed-off-by: Guodong Xu <guodong.xu@linaro.org>

commit d637ad5c611435ed2ca3a4adfdb33e7a64d4b148
Author: Guodong Xu <guodong.xu@linaro.org>
Date:   Sun Sep 3 06:36:37 2023 +0800

    uadk_provider: iv_len in SM4_ECB mode must be 0
    
    iv_len of ECB mode must be 0. Without this, openssl's evp_test
    will fail at:
    
    [openssl.git]/test/evp_test.c, cipher_test_run():
      if (!cdat->iv && EVP_CIPHER_get_iv_length(cdat->cipher)) {
    
    Signed-off-by: Guodong Xu <guodong.xu@linaro.org>
