### PR TITLE
uadk_prov_cipher: fix build warning

### DIFF
--- a/src/uadk_prov_cipher.c
+++ b/src/uadk_prov_cipher.c
@@ -223,8 +223,6 @@ static int uadk_prov_cipher_sw_init(struct cipher_priv_ctx *priv,
 static int uadk_prov_cipher_soft_work(struct cipher_priv_ctx *priv, unsigned char *out,
 				      int *outl, const unsigned char *in, size_t len)
 {
-	int sw_final_len = 0;
-
 	if (priv->sw_cipher == NULL)
 		return 0;
 
@@ -263,7 +261,7 @@ static int uadk_prov_cipher_init(struct cipher_priv_ctx *priv,
 				 const unsigned char *iv, size_t ivlen)
 {
 	int cipher_counts = ARRAY_SIZE(cipher_info_table);
-	int ret, i;
+	int i;
 
 	if (iv)
 		memcpy(priv->iv, iv, ivlen);


### PR DESCRIPTION
With CFLAGS=-Wall, build reports warning

uadk_prov_cipher.c: In function 'uadk_prov_cipher_soft_work': uadk_prov_cipher.c:226:6: warning: unused variable 'sw_final_len' [-Wunused-variable]
  226 |  int sw_final_len = 0;
      |      ^~~~~~~~~~~~
uadk_prov_cipher.c: In function 'uadk_prov_cipher_init':
uadk_prov_cipher.c:266:6: warning: unused variable 'ret' [-Wunused-variable]
  266 |  int ret, i;
      |      ^~~