### PR TITLE
configure: use LT_INIT to replace obsolete AC_PROG_LIBTOOL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,8 +6,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
 
 AC_PROG_CC
-AC_PROG_LIBTOOL
-AM_PROG_LIBTOOL
+LT_INIT
 
 AC_ARG_ENABLE(kae,
 	      AS_HELP_STRING([--enable-kae],[Enable kae support]))

--- a/src/uadk_prov.h
+++ b/src/uadk_prov.h
@@ -124,4 +124,7 @@ void uadk_prov_destroy_digest(void);
 void uadk_prov_destroy_cipher(void);
 void uadk_prov_destroy_rsa(void);
 void uadk_prov_destroy_dh(void);
+
+/* offload small packets to sw */
+extern int enable_sw_offload;
 #endif

--- a/src/uadk_prov_digest.c
+++ b/src/uadk_prov_digest.c
@@ -29,6 +29,7 @@
 #include <uadk/wd_sched.h>
 #include "uadk.h"
 #include "uadk_async.h"
+#include "uadk_prov.h"
 #include "uadk_utils.h"
 
 #define UADK_DO_SOFT	(-0xE0)
@@ -288,7 +289,8 @@ static int uadk_digest_init(struct digest_priv_ctx *priv)
 		return 0;
 	}
 
-	uadk_digests_soft_md(priv);
+	if (enable_sw_offload)
+		uadk_digests_soft_md(priv);
 
 	return 1;
 
@@ -403,7 +405,8 @@ static int uadk_do_digest_sync(struct digest_priv_ctx *priv)
 {
 	int ret;
 
-	if (priv->req.in_bytes <= priv->switch_threshold &&
+	if (priv->soft_md &&
+	    priv->req.in_bytes <= priv->switch_threshold &&
 	    priv->state == SEC_DIGEST_INIT)
 		return 0;
 

--- a/uadk_provider.cnf
+++ b/uadk_provider.cnf
@@ -13,3 +13,4 @@ uadk_provider = uadk_sect
 
 [uadk_sect]
 activate = 1
+enable_sw_offload = 0


### PR DESCRIPTION
resolve configure warning
configure.ac:9: warning: The macro `AC_PROG_LIBTOOL' is obsolete.