### PR TITLE
uadk_engine: some bugfix and cleanup

### DIFF
--- a/src/uadk.h
+++ b/src/uadk.h
@@ -21,6 +21,7 @@
 
 #define ARRAY_SIZE(x)		(sizeof(x) / sizeof((x)[0]))
 #define ENV_STRING_LEN		256
+#define ENGINE_SEND_MAX_CNT	90000000
 #define ENGINE_RECV_MAX_CNT	60000000
 #define UADK_UNINIT		0
 #define UADK_INIT_SUCCESS	1

--- a/src/uadk.h
+++ b/src/uadk.h
@@ -22,6 +22,10 @@
 #define ARRAY_SIZE(x)		(sizeof(x) / sizeof((x)[0]))
 #define ENV_STRING_LEN		256
 #define ENGINE_RECV_MAX_CNT	60000000
+#define UADK_UNINIT		0
+#define UADK_INIT_SUCCESS	1
+#define UADK_INIT_FAIL		2
+#define UADK_DEVICE_ERROR	3
 
 enum {
 	HW_V2,

--- a/src/uadk_async.c
+++ b/src/uadk_async.c
@@ -302,8 +302,10 @@ int async_wake_job(ASYNC_JOB *job)
 
 	ret = ASYNC_WAIT_CTX_get_fd(waitctx, uadk_async_key, &efd, &custom);
 	if (ret > 0) {
-		if (write(efd, &buf, sizeof(uint64_t)) == -1)
+		if (write(efd, &buf, sizeof(uint64_t)) == -1) {
 			fprintf(stderr, "failed to write to fd: %d - error: %d\n", efd, errno);
+			return errno;
+		}
 	}
 
 	return ret;
@@ -364,7 +366,7 @@ int async_module_init(void)
 	if (pthread_mutex_init(&(poll_queue.async_task_mutex), NULL) < 0)
 		return 0;
 
-	poll_queue.head = calloc(ASYNC_QUEUE_TASK_NUM, sizeof(struct async_poll_task));
+	poll_queue.head = OPENSSL_malloc(ASYNC_QUEUE_TASK_NUM * sizeof(struct async_poll_task));
 	if (poll_queue.head == NULL)
 		return 0;
 

--- a/src/uadk_async.c
+++ b/src/uadk_async.c
@@ -132,6 +132,7 @@ void async_poll_task_free(void)
 	poll_queue.head = NULL;
 
 	pthread_mutex_unlock(&poll_queue.async_task_mutex);
+	pthread_attr_destroy(&poll_queue.thread_attr);
 	sem_destroy(&poll_queue.empty_sem);
 	sem_destroy(&poll_queue.full_sem);
 	pthread_mutex_destroy(&poll_queue.async_task_mutex);
@@ -359,7 +360,6 @@ static void *async_poll_process_func(void *args)
 int async_module_init(void)
 {
 	pthread_t thread_id;
-	pthread_attr_t thread_attr;
 
 	memset(&poll_queue, 0, sizeof(struct async_poll_queue));
 
@@ -378,9 +378,9 @@ int async_module_init(void)
 
 	uadk_e_set_async_poll_state(ENABLE_ASYNC_POLLING);
 
-	pthread_attr_init(&thread_attr);
-	pthread_attr_setdetachstate(&thread_attr, PTHREAD_CREATE_DETACHED);
-	if (pthread_create(&thread_id, &thread_attr, async_poll_process_func, NULL))
+	pthread_attr_init(&poll_queue.thread_attr);
+	pthread_attr_setdetachstate(&poll_queue.thread_attr, PTHREAD_CREATE_DETACHED);
+	if (pthread_create(&thread_id, &poll_queue.thread_attr, async_poll_process_func, NULL))
 		goto err;
 
 	poll_queue.thread_id = thread_id;

--- a/src/uadk_async.h
+++ b/src/uadk_async.h
@@ -69,6 +69,7 @@ struct async_poll_queue {
 	sem_t full_sem;
 	pthread_mutex_t async_task_mutex;
 	pthread_t thread_id;
+	pthread_attr_t thread_attr;
 };
 
 int async_setup_async_event_notification(struct async_op *op);

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -185,7 +185,7 @@ static int uadk_e_cipher_sw_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 
 	priv = (struct cipher_priv_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
 	if (unlikely(priv == NULL)) {
-		fprintf(stderr, "uadk engine state is NULL.\n");
+		fprintf(stderr, "priv get from cipher ctx is NULL.\n");
 		return 0;
 	}
 
@@ -235,7 +235,7 @@ static int uadk_e_cipher_soft_work(EVP_CIPHER_CTX *ctx, unsigned char *out,
 
 	priv = (struct cipher_priv_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
 	if (unlikely(priv == NULL)) {
-		fprintf(stderr, "uadk engine state is NULL.\n");
+		fprintf(stderr, "priv get from cipher ctx is NULL.\n");
 		return 0;
 	}
 
@@ -277,7 +277,7 @@ static void uadk_e_cipher_sw_cleanup(EVP_CIPHER_CTX *ctx)
 	struct cipher_priv_ctx *priv =
 		(struct cipher_priv_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
 
-	if (priv->sw_ctx_data) {
+	if (priv && priv->sw_ctx_data) {
 		OPENSSL_free(priv->sw_ctx_data);
 		priv->sw_ctx_data = NULL;
 	}
@@ -500,6 +500,11 @@ static int uadk_e_cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 	int nid, ret;
 	__u32 i;
 
+	if (unlikely(!priv)) {
+		fprintf(stderr, "priv get from cipher ctx is NULL.\n");
+		return 0;
+	}
+
 	if (unlikely(!key)) {
 		fprintf(stderr, "ctx init parameter key is NULL.\n");
 		return 0;
@@ -541,7 +546,7 @@ static int uadk_e_cipher_cleanup(EVP_CIPHER_CTX *ctx)
 
 	uadk_e_cipher_sw_cleanup(ctx);
 
-	if (priv->sess) {
+	if (priv && priv->sess) {
 		wd_cipher_free_sess(priv->sess);
 		priv->sess = 0;
 	}
@@ -751,6 +756,11 @@ static int uadk_e_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 		(struct cipher_priv_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
 	struct async_op op;
 	int ret;
+
+	if (unlikely(!priv)) {
+		fprintf(stderr, "priv get from cipher ctx is NULL.\n");
+		return 0;
+	}
 
 	priv->req.src = (unsigned char *)in;
 	priv->req.in_bytes = inlen;

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -811,19 +811,18 @@ out_notify:
 	return ret;
 }
 
-#define UADK_CIPHER_DESCR(name, block_size, key_size, iv_len, flags, ctx_size, \
-	init, cipher, cleanup, set_params, get_params) \
+#define UADK_CIPHER_DESCR(name, block_size, key_size, iv_len, flags) \
 do { \
 	uadk_##name = EVP_CIPHER_meth_new(NID_##name, block_size, key_size); \
 	if (uadk_##name == 0 || \
-		!EVP_CIPHER_meth_set_iv_length(uadk_##name, iv_len) || \
-		!EVP_CIPHER_meth_set_flags(uadk_##name, flags) || \
-		!EVP_CIPHER_meth_set_impl_ctx_size(uadk_##name, ctx_size) || \
-		!EVP_CIPHER_meth_set_init(uadk_##name, init) || \
-		!EVP_CIPHER_meth_set_do_cipher(uadk_##name, cipher) || \
-		!EVP_CIPHER_meth_set_cleanup(uadk_##name, cleanup) || \
-		!EVP_CIPHER_meth_set_set_asn1_params(uadk_##name, set_params) || \
-		!EVP_CIPHER_meth_set_get_asn1_params(uadk_##name, get_params)) \
+	    !EVP_CIPHER_meth_set_iv_length(uadk_##name, iv_len) || \
+	    !EVP_CIPHER_meth_set_flags(uadk_##name, flags) || \
+	    !EVP_CIPHER_meth_set_impl_ctx_size(uadk_##name, sizeof(struct cipher_priv_ctx)) || \
+	    !EVP_CIPHER_meth_set_init(uadk_##name, uadk_e_cipher_init) || \
+	    !EVP_CIPHER_meth_set_do_cipher(uadk_##name, uadk_e_do_cipher) || \
+	    !EVP_CIPHER_meth_set_cleanup(uadk_##name, uadk_e_cipher_cleanup) || \
+	    !EVP_CIPHER_meth_set_set_asn1_params(uadk_##name, EVP_CIPHER_set_asn1_iv) || \
+	    !EVP_CIPHER_meth_set_get_asn1_params(uadk_##name, EVP_CIPHER_get_asn1_iv)) \
 		return 0; \
 } while (0)
 
@@ -833,171 +832,99 @@ EVP_CIPHER *uadk_create_cipher_meth(int nid)
 
 	switch (nid) {
 	case NID_aes_128_cbc:
-		UADK_CIPHER_DESCR(aes_128_cbc, 16, 16, 16, EVP_CIPH_CBC_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_128_cbc, 16, 16, 16, EVP_CIPH_CBC_MODE);
 		cipher = uadk_aes_128_cbc;
 		break;
 	case NID_aes_192_cbc:
-		UADK_CIPHER_DESCR(aes_192_cbc, 16, 24, 16, EVP_CIPH_CBC_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_192_cbc, 16, 24, 16, EVP_CIPH_CBC_MODE);
 		cipher = uadk_aes_192_cbc;
 		break;
 	case NID_aes_256_cbc:
-		UADK_CIPHER_DESCR(aes_256_cbc, 16, 32, 16, EVP_CIPH_CBC_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_256_cbc, 16, 32, 16, EVP_CIPH_CBC_MODE);
 		cipher = uadk_aes_256_cbc;
 		break;
 	case NID_aes_128_ecb:
-		UADK_CIPHER_DESCR(aes_128_ecb, 16, 16, 0, EVP_CIPH_ECB_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_128_ecb, 16, 16, 0, EVP_CIPH_ECB_MODE);
 		cipher = uadk_aes_128_ecb;
 		break;
 	case NID_aes_192_ecb:
-		UADK_CIPHER_DESCR(aes_192_ecb, 16, 24, 0, EVP_CIPH_ECB_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_192_ecb, 16, 24, 0, EVP_CIPH_ECB_MODE);
 		cipher = uadk_aes_192_ecb;
 		break;
 	case NID_aes_256_ecb:
-		UADK_CIPHER_DESCR(aes_256_ecb, 16, 32, 0, EVP_CIPH_ECB_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_256_ecb, 16, 32, 0, EVP_CIPH_ECB_MODE);
 		cipher = uadk_aes_256_ecb;
 		break;
 	case NID_aes_128_xts:
-		UADK_CIPHER_DESCR(aes_128_xts, 1, 32, 16, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_128_xts, 1, 32, 16, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV);
 		cipher = uadk_aes_128_xts;
 		break;
 	case NID_aes_256_xts:
-		UADK_CIPHER_DESCR(aes_256_xts, 1, 64, 16, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_256_xts, 1, 64, 16, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV);
 		cipher = uadk_aes_256_xts;
 		break;
 	case NID_sm4_cbc:
-		UADK_CIPHER_DESCR(sm4_cbc, 16, 16, 16, EVP_CIPH_CBC_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(sm4_cbc, 16, 16, 16, EVP_CIPH_CBC_MODE);
 		cipher = uadk_sm4_cbc;
 		break;
 	case NID_sm4_ecb:
-		UADK_CIPHER_DESCR(sm4_ecb, 16, 16, 0, EVP_CIPH_ECB_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(sm4_ecb, 16, 16, 0, EVP_CIPH_ECB_MODE);
 		cipher = uadk_sm4_ecb;
 		break;
 	case NID_des_ede3_cbc:
-		UADK_CIPHER_DESCR(des_ede3_cbc, 8, 24, 8, EVP_CIPH_CBC_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(des_ede3_cbc, 8, 24, 8, EVP_CIPH_CBC_MODE);
 		cipher = uadk_des_ede3_cbc;
 		break;
 	case NID_des_ede3_ecb:
-		UADK_CIPHER_DESCR(des_ede3_ecb, 8, 24, 0, EVP_CIPH_ECB_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(des_ede3_ecb, 8, 24, 0, EVP_CIPH_ECB_MODE);
 		cipher = uadk_des_ede3_ecb;
 		break;
 	case NID_aes_128_ctr:
-		UADK_CIPHER_DESCR(aes_128_ctr, 1, 16, 16, EVP_CIPH_CTR_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_128_ctr, 1, 16, 16, EVP_CIPH_CTR_MODE);
 		cipher = uadk_aes_128_ctr;
 		break;
 	case NID_aes_192_ctr:
-		UADK_CIPHER_DESCR(aes_192_ctr, 1, 24, 16, EVP_CIPH_CTR_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_192_ctr, 1, 24, 16, EVP_CIPH_CTR_MODE);
 		cipher = uadk_aes_192_ctr;
 		break;
 	case NID_aes_256_ctr:
-		UADK_CIPHER_DESCR(aes_256_ctr, 1, 32, 16, EVP_CIPH_CTR_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_256_ctr, 1, 32, 16, EVP_CIPH_CTR_MODE);
 		cipher = uadk_aes_256_ctr;
 		break;
 	case NID_aes_128_ofb128:
-		UADK_CIPHER_DESCR(aes_128_ofb128, 1, 16, 16, EVP_CIPH_OFB_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_128_ofb128, 1, 16, 16, EVP_CIPH_OFB_MODE);
 		cipher = uadk_aes_128_ofb128;
 		break;
 	case NID_aes_192_ofb128:
-		UADK_CIPHER_DESCR(aes_192_ofb128, 1, 24, 16, EVP_CIPH_OFB_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_192_ofb128, 1, 24, 16, EVP_CIPH_OFB_MODE);
 		cipher = uadk_aes_192_ofb128;
 		break;
 	case NID_aes_256_ofb128:
-		UADK_CIPHER_DESCR(aes_256_ofb128, 1, 32, 16, EVP_CIPH_OFB_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_256_ofb128, 1, 32, 16, EVP_CIPH_OFB_MODE);
 		cipher = uadk_aes_256_ofb128;
 		break;
 	case NID_aes_128_cfb128:
-		UADK_CIPHER_DESCR(aes_128_cfb128, 1, 16, 16, EVP_CIPH_CFB_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_128_cfb128, 1, 16, 16, EVP_CIPH_CFB_MODE);
 		cipher = uadk_aes_128_cfb128;
 		break;
 	case NID_aes_192_cfb128:
-		UADK_CIPHER_DESCR(aes_192_cfb128, 1, 24, 16, EVP_CIPH_CFB_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_192_cfb128, 1, 24, 16, EVP_CIPH_CFB_MODE);
 		cipher = uadk_aes_192_cfb128;
 		break;
 	case NID_aes_256_cfb128:
-		UADK_CIPHER_DESCR(aes_256_cfb128, 1, 32, 16, EVP_CIPH_CFB_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(aes_256_cfb128, 1, 32, 16, EVP_CIPH_CFB_MODE);
 		cipher = uadk_aes_256_cfb128;
 		break;
 	case NID_sm4_ofb128:
-		UADK_CIPHER_DESCR(sm4_ofb128, 1, 16, 16, EVP_CIPH_OFB_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(sm4_ofb128, 1, 16, 16, EVP_CIPH_OFB_MODE);
 		cipher = uadk_sm4_ofb128;
 		break;
 	case NID_sm4_cfb128:
-		UADK_CIPHER_DESCR(sm4_cfb128, 1, 16, 16, EVP_CIPH_OFB_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(sm4_cfb128, 1, 16, 16, EVP_CIPH_OFB_MODE);
 		cipher = uadk_sm4_cfb128;
 		break;
 	case NID_sm4_ctr:
-		UADK_CIPHER_DESCR(sm4_ctr, 1, 16, 16, EVP_CIPH_CTR_MODE,
-				sizeof(struct cipher_priv_ctx), uadk_e_cipher_init,
-				uadk_e_do_cipher, uadk_e_cipher_cleanup,
-				EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
+		UADK_CIPHER_DESCR(sm4_ctr, 1, 16, 16, EVP_CIPH_CTR_MODE);
 		cipher = uadk_sm4_ctr;
 		break;
 	default:

--- a/src/uadk_dh.c
+++ b/src/uadk_dh.c
@@ -716,7 +716,7 @@ static int dh_do_crypto(struct uadk_dh_sess *dh_sess)
 {
 	struct uadk_e_cb_info cb_param;
 	struct async_op op;
-	int idx, ret;
+	int idx, ret, cnt;
 
 	ret = async_setup_async_event_notification(&op);
 	if (!ret) {
@@ -742,12 +742,17 @@ static int dh_do_crypto(struct uadk_dh_sess *dh_sess)
 			goto err;
 
 		op.idx = idx;
-
+		cnt = 0;
 		do {
 			ret = wd_do_dh_async(dh_sess->sess, &dh_sess->req);
-			if (ret < 0 && ret != -EBUSY) {
-				if (ret == -WD_HW_EACCESS)
+			if (unlikely(ret < 0)) {
+				if (unlikely(ret == -WD_HW_EACCESS))
 					uadk_e_dh_set_status();
+				else if (unlikely(cnt++ > ENGINE_SEND_MAX_CNT))
+					fprintf(stderr, "do dh async operation timeout.\n");
+				else
+					continue;
+
 				async_free_poll_task(op.idx, 0);
 				goto err;
 			}

--- a/src/uadk_digest.c
+++ b/src/uadk_digest.c
@@ -767,7 +767,7 @@ static int uadk_e_digest_final(EVP_MD_CTX *ctx, unsigned char *digest)
 {
 	struct digest_priv_ctx *priv =
 		(struct digest_priv_ctx *)EVP_MD_CTX_md_data(ctx);
-	struct async_op op;
+	struct async_op *op;
 	int ret = 1;
 
 	digest_set_msg_state(priv, true);
@@ -782,13 +782,18 @@ static int uadk_e_digest_final(EVP_MD_CTX *ctx, unsigned char *digest)
 	if (priv->e_nid == NID_sha384)
 		priv->req.out_bytes = WD_DIGEST_SHA384_LEN;
 
-	ret = async_setup_async_event_notification(&op);
+	op = malloc(sizeof(struct async_op));
+	if (!op)
+		return 0;
+
+	ret = async_setup_async_event_notification(op);
 	if (unlikely(!ret)) {
 		fprintf(stderr, "failed to setup async event notification.\n");
+		free(op);
 		return 0;
 	}
 
-	if (op.job == NULL) {
+	if (!op->job) {
 		/* Synchronous, only the synchronous mode supports soft computing */
 		if (unlikely(priv->switch_flag == UADK_DO_SOFT)) {
 			ret = digest_soft_final(priv, digest);
@@ -800,12 +805,13 @@ static int uadk_e_digest_final(EVP_MD_CTX *ctx, unsigned char *digest)
 		if (!ret)
 			goto sync_err;
 	} else {
-		ret = do_digest_async(priv, &op);
+		ret = do_digest_async(priv, op);
 		if (!ret)
 			goto clear;
 	}
 	memcpy(digest, priv->req.out, priv->req.out_bytes);
 
+	free(op);
 	return 1;
 
 sync_err:
@@ -817,6 +823,7 @@ sync_err:
 	}
 clear:
 	async_clear_async_event_notification();
+	free(op);
 	return ret;
 }
 

--- a/src/uadk_digest.c
+++ b/src/uadk_digest.c
@@ -535,6 +535,11 @@ static int uadk_e_digest_init(EVP_MD_CTX *ctx)
 	__u32 i;
 	int ret;
 
+	if (unlikely(!priv)) {
+		fprintf(stderr, "priv get from digest ctx is NULL.\n");
+		return 0;
+	}
+
 	priv->e_nid = EVP_MD_nid(EVP_MD_CTX_md(ctx));
 
 	digest_priv_ctx_reset(priv);
@@ -587,6 +592,11 @@ static void digest_update_out_length(EVP_MD_CTX *ctx)
 	struct digest_priv_ctx *priv =
 		(struct digest_priv_ctx *)EVP_MD_CTX_md_data(ctx);
 
+	if (unlikely(!priv)) {
+		fprintf(stderr, "priv get from digest ctx is NULL.\n");
+		return;
+	}
+
 	/* Sha224 and Sha384 need full length mac buffer as doing long hash */
 	if (priv->e_nid == NID_sha224)
 		priv->req.out_bytes = WD_DIGEST_SHA224_FULL_LEN;
@@ -613,6 +623,11 @@ static int digest_update_inner(EVP_MD_CTX *ctx, const void *data, size_t data_le
 	size_t left_len = data_len;
 	int copy_to_bufflen;
 	int ret;
+
+	if (unlikely(!priv)) {
+		fprintf(stderr, "priv get from digest ctx is NULL.\n");
+		return 0;
+	}
 
 	digest_update_out_length(ctx);
 	digest_set_msg_state(priv, false);
@@ -670,6 +685,11 @@ static int uadk_e_digest_update(EVP_MD_CTX *ctx, const void *data, size_t data_l
 {
 	struct digest_priv_ctx *priv =
 		(struct digest_priv_ctx *)EVP_MD_CTX_md_data(ctx);
+
+	if (unlikely(!priv)) {
+		fprintf(stderr, "priv get from digest ctx is NULL.\n");
+		return 0;
+	}
 
 	if (unlikely(priv->switch_flag == UADK_DO_SOFT))
 		goto soft_update;
@@ -770,6 +790,11 @@ static int uadk_e_digest_final(EVP_MD_CTX *ctx, unsigned char *digest)
 	struct async_op *op;
 	int ret = 1;
 
+	if (unlikely(!priv)) {
+		fprintf(stderr, "priv get from digest ctx is NULL.\n");
+		return 0;
+	}
+
 	digest_set_msg_state(priv, true);
 	priv->req.in = priv->data;
 	priv->req.out = priv->out;
@@ -862,6 +887,11 @@ static int uadk_e_digest_copy(EVP_MD_CTX *to, const EVP_MD_CTX *from)
 
 	if (!t)
 		return 1;
+
+	if (!f) {
+		fprintf(stderr, "priv get from digest ctx is NULL.\n");
+		return 0;
+	}
 
 	if (t->sess) {
 		params.numa_id = -1;

--- a/src/uadk_ec.c
+++ b/src/uadk_ec.c
@@ -479,19 +479,19 @@ static ECDSA_SIG *ecdsa_do_sign(const unsigned char *dgst, int dlen,
 
 	ret = ecdsa_do_sign_check(eckey, dgst, dlen, in_kinv, in_r);
 	if (ret)
-		goto do_soft;
+		goto soft_log;
 
 	ret = uadk_e_ecc_get_support_state(ECDSA_SUPPORT);
 	if (!ret)
-		goto do_soft;
+		goto soft_log;
 
 	ret = uadk_init_ecc();
-	if (ret)
+	if (ret != UADK_INIT_SUCCESS)
 		goto do_soft;
 
 	sess = ecc_alloc_sess(eckey, "ecdsa");
 	if (!sess)
-		goto do_soft;
+		goto soft_log;
 
 	memset(&req, 0, sizeof(req));
 	tdgst.data = (void *)dgst;
@@ -521,8 +521,9 @@ uninit_iot:
 	wd_ecc_del_out(sess, req.dst);
 free_sess:
 	wd_ecc_free_sess(sess);
-do_soft:
+soft_log:
 	fprintf(stderr, "switch to execute openssl software calculation.\n");
+do_soft:
 	return openssl_do_sign(dgst, dlen, in_kinv, in_r, eckey);
 }
 
@@ -677,19 +678,19 @@ static int ecdsa_do_verify(const unsigned char *dgst, int dlen,
 
 	ret = ecdsa_do_verify_check(eckey, dgst, dlen, sig);
 	if (ret)
-		goto do_soft;
+		goto soft_log;
 
 	ret = uadk_e_ecc_get_support_state(ECDSA_SUPPORT);
 	if (!ret)
-		goto do_soft;
+		goto soft_log;
 
 	ret = uadk_init_ecc();
-	if (ret)
+	if (ret != UADK_INIT_SUCCESS)
 		goto do_soft;
 
 	sess = ecc_alloc_sess(eckey, "ecdsa");
 	if (!sess)
-		goto do_soft;
+		goto soft_log;
 
 	memset(&req, 0, sizeof(req));
 	tdgst.data = (void *)dgst;
@@ -717,8 +718,9 @@ uninit_iot:
 	wd_ecc_del_in(sess, req.src);
 free_sess:
 	wd_ecc_free_sess(sess);
-do_soft:
+soft_log:
 	fprintf(stderr, "switch to execute openssl software calculation.\n");
+do_soft:
 	return openssl_do_verify(dgst, dlen, sig, eckey);
 }
 
@@ -970,23 +972,23 @@ static int sm2_generate_key(EC_KEY *eckey)
 
 	ret = ecc_genkey_check(eckey);
 	if (ret)
-		goto do_soft;
+		goto soft_log;
 
 	ret = eckey_create_key(eckey);
 	if (!ret)
-		goto do_soft;
+		goto soft_log;
 
 	ret = uadk_e_ecc_get_support_state(SM2_SUPPORT);
 	if (!ret)
-		goto do_soft;
+		goto soft_log;
 
 	ret = uadk_init_ecc();
-	if (ret)
+	if (ret != UADK_INIT_SUCCESS)
 		goto do_soft;
 
 	sess = ecc_alloc_sess(eckey, "sm2");
 	if (!sess)
-		goto do_soft;
+		goto soft_log;
 
 	memset(&req, 0, sizeof(req));
 	ret = sm2_keygen_init_iot(sess, &req);
@@ -1010,8 +1012,9 @@ uninit_iot:
 	wd_ecc_del_out(sess, req.dst);
 free_sess:
 	wd_ecc_free_sess(sess);
-do_soft:
+soft_log:
 	fprintf(stderr, "switch to execute openssl software calculation.\n");
+do_soft:
 	return openssl_do_generate(eckey);
 }
 
@@ -1030,7 +1033,6 @@ static int ecdh_keygen_init_iot(handle_t sess, struct wd_ecc_req *req,
 
 	return 1;
 }
-
 
 static int ecdh_compkey_init_iot(handle_t sess, struct wd_ecc_req *req,
 				 const EC_POINT *pubkey, const EC_KEY *ecdh)
@@ -1201,23 +1203,23 @@ static int ecdh_generate_key(EC_KEY *ecdh)
 
 	ret = ecc_genkey_check(ecdh);
 	if (ret)
-		goto do_soft;
+		goto soft_log;
 
 	ret = ecdh_create_key(ecdh);
 	if (!ret)
-		goto do_soft;
+		goto soft_log;
 
 	ret = uadk_e_ecc_get_support_state(ECDH_SUPPORT);
 	if (!ret)
-		goto do_soft;
+		goto soft_log;
 
 	ret = uadk_init_ecc();
-	if (ret)
+	if (ret != UADK_INIT_SUCCESS)
 		goto do_soft;
 
 	sess = ecc_alloc_sess(ecdh, "ecdh");
 	if (!sess)
-		goto do_soft;
+		goto soft_log;
 
 	memset(&req, 0, sizeof(req));
 	ret = ecdh_keygen_init_iot(sess, &req, ecdh);
@@ -1245,8 +1247,9 @@ uninit_iot:
 	wd_ecc_del_out(sess, req.dst);
 free_sess:
 	wd_ecc_free_sess(sess);
-do_soft:
+soft_log:
 	fprintf(stderr, "switch to execute openssl software calculation.\n");
+do_soft:
 	return openssl_do_generate(ecdh);
 }
 
@@ -1319,19 +1322,19 @@ static int ecdh_compute_key(unsigned char **out, size_t *outlen,
 
 	ret = ecc_compkey_check(out, outlen, pub_key, ecdh);
 	if (!ret)
-		goto do_soft;
+		goto soft_log;
 
 	ret = uadk_e_ecc_get_support_state(ECDH_SUPPORT);
 	if (!ret)
-		goto do_soft;
+		goto soft_log;
 
 	ret = uadk_init_ecc();
-	if (ret)
+	if (ret != UADK_INIT_SUCCESS)
 		goto do_soft;
 
 	sess = ecc_alloc_sess(ecdh, "ecdh");
 	if (!sess)
-		goto do_soft;
+		goto soft_log;
 
 	memset(&req, 0, sizeof(req));
 	ret = ecdh_compkey_init_iot(sess, &req, pub_key, ecdh);
@@ -1365,8 +1368,9 @@ uninit_iot:
 	wd_ecc_del_out(sess, req.dst);
 free_sess:
 	wd_ecc_free_sess(sess);
-do_soft:
+soft_log:
 	fprintf(stderr, "switch to execute openssl software calculation.\n");
+do_soft:
 	return openssl_do_compute(out, outlen, pub_key, ecdh);
 }
 

--- a/src/uadk_ec.c
+++ b/src/uadk_ec.c
@@ -328,6 +328,10 @@ static int set_digest(handle_t sess, struct wd_dtb *e,
 
 	if (dlen << TRANS_BITS_BYTES_SHIFT > order_bits) {
 		m = BN_new();
+		if (!m) {
+			fprintf(stderr, "failed to BN_new BIGNUM m\n");
+			return -1;
+		}
 
 		/* Need to truncate digest if it is too long: first truncate
 		 * whole bytes

--- a/src/uadk_ec.c
+++ b/src/uadk_ec.c
@@ -548,8 +548,11 @@ static int ecdsa_sign(int type, const unsigned char *dgst, int dlen,
 		goto err;
 	}
 
-	*siglen = i2d_ECDSA_SIG(s, &sig);
+	if (siglen)
+		*siglen = i2d_ECDSA_SIG(s, &sig);
+
 	ECDSA_SIG_free(s);
+
 	return 1;
 
 err:

--- a/src/uadk_ecx.c
+++ b/src/uadk_ecx.c
@@ -85,10 +85,8 @@ static int x25519_init(EVP_PKEY_CTX *ctx)
 	}
 
 	ret = uadk_init_ecc();
-	if (ret) {
-		fprintf(stderr, "failed to uadk_init_ecc, ret = %d\n", ret);
+	if (ret != UADK_INIT_SUCCESS)
 		return UADK_E_FAIL;
-	}
 
 	x25519_ctx = calloc(1, sizeof(struct ecx_ctx));
 	if (!x25519_ctx) {
@@ -141,10 +139,8 @@ static int x448_init(EVP_PKEY_CTX *ctx)
 	}
 
 	ret = uadk_init_ecc();
-	if (ret) {
-		fprintf(stderr, "failed to do uadk_init_ecc, ret = %d\n", ret);
+	if (ret != UADK_INIT_SUCCESS)
 		return UADK_E_FAIL;
-	}
 
 	x448_ctx = calloc(1, sizeof(struct ecx_ctx));
 	if (!x448_ctx) {

--- a/src/uadk_rsa.c
+++ b/src/uadk_rsa.c
@@ -1491,9 +1491,14 @@ static int uadk_e_rsa_public_encrypt(int flen, const unsigned char *from,
 	}
 
 	ret = rsa_create_pub_bn_ctx(rsa, pub_enc, &from_buf, &num_bytes);
-	if (ret <= 0 || flen > num_bytes) {
+	if (ret <= 0) {
 		ret = UADK_DO_SOFT;
 		goto free_sess;
+	}
+
+	if (flen > num_bytes) {
+		ret = UADK_DO_SOFT;
+		goto free_buf;
 	}
 
 	ret = add_rsa_pubenc_padding(flen, from, from_buf, num_bytes, padding);
@@ -1756,9 +1761,14 @@ static int uadk_e_rsa_public_verify(int flen, const unsigned char *from,
 	}
 
 	ret = rsa_create_pub_bn_ctx(rsa, pub, &from_buf, &num_bytes);
-	if (ret <= 0 || flen > num_bytes) {
+	if (ret <= 0) {
 		ret = UADK_DO_SOFT;
 		goto free_sess;
+	}
+
+	if (flen > num_bytes) {
+		ret = UADK_DO_SOFT;
+		goto free_buf;
 	}
 
 	ret = rsa_fill_pubkey(pub, rsa_sess, from_buf, to);

--- a/src/uadk_rsa.c
+++ b/src/uadk_rsa.c
@@ -1358,7 +1358,7 @@ static void rsa_free_pub_bn_ctx(unsigned char **from_buf)
 }
 
 static int rsa_create_pri_bn_ctx(RSA *rsa, struct rsa_prikey_param *pri,
-				 unsigned char **from_buf, int *num_bytes)
+				 unsigned char **from_buf, int *num_bytes, int flen)
 {
 	RSA_get0_key(rsa, &pri->n, &pri->e, &pri->d);
 	if (!(pri->n) || !(pri->e) || !(pri->d))
@@ -1374,6 +1374,9 @@ static int rsa_create_pri_bn_ctx(RSA *rsa, struct rsa_prikey_param *pri,
 
 	*num_bytes = BN_num_bytes(pri->n);
 	if (!(*num_bytes))
+		return UADK_E_FAIL;
+
+	if (flen > *num_bytes)
 		return UADK_E_FAIL;
 
 	*from_buf = OPENSSL_malloc(*num_bytes);
@@ -1578,8 +1581,8 @@ static int uadk_e_rsa_private_decrypt(int flen, const unsigned char *from,
 		goto free_pkey;
 	}
 
-	ret = rsa_create_pri_bn_ctx(rsa, pri, &from_buf, &num_bytes);
-	if (ret <= 0 || flen > num_bytes) {
+	ret = rsa_create_pri_bn_ctx(rsa, pri, &from_buf, &num_bytes, flen);
+	if (ret <= 0) {
 		ret = UADK_DO_SOFT;
 		goto free_sess;
 	}
@@ -1665,8 +1668,8 @@ static int uadk_e_rsa_private_sign(int flen, const unsigned char *from,
 		goto free_pkey;
 	}
 
-	ret = rsa_create_pri_bn_ctx(rsa, pri, &from_buf, &num_bytes);
-	if (ret <= 0 || flen > num_bytes) {
+	ret = rsa_create_pri_bn_ctx(rsa, pri, &from_buf, &num_bytes, flen);
+	if (ret <= 0) {
 		ret = UADK_DO_SOFT;
 		goto free_sess;
 	}

--- a/src/uadk_sm2.c
+++ b/src/uadk_sm2.c
@@ -149,7 +149,7 @@ static int get_hash_type(int nid_hash)
 }
 
 static int compute_hash(const char *in, size_t in_len,
-		       char *out, size_t out_len, void *usr)
+			char *out, size_t out_len, void *usr)
 {
 	const EVP_MD *digest = (const EVP_MD *)usr;
 	EVP_MD_CTX *hash = EVP_MD_CTX_new();
@@ -377,7 +377,7 @@ static int sign_bin_to_ber(EC_KEY *ec, struct wd_dtb *r, struct wd_dtb *s,
 	e_sig = ECDSA_SIG_new();
 	if (!e_sig) {
 		fprintf(stderr, "failed to ECDSA_SIG_new\n");
-		return -EINVAL;
+		return -ENOMEM;
 	}
 
 	br = BN_bin2bn((void *)r->data, r->dsize, NULL);
@@ -1200,6 +1200,7 @@ static int sm2_init(EVP_PKEY_CTX *ctx)
 	ret = uadk_e_ecc_get_support_state(SM2_SUPPORT);
 	if (!ret) {
 		fprintf(stderr, "sm2 is not supported\n");
+		free(smctx);
 		return 0;
 	}
 
@@ -1284,6 +1285,8 @@ static int sm2_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 		}
 		goto set_data;
 	case EVP_PKEY_CTRL_GET_MD:
+		if (!p2)
+			return 0;
 		*(const EVP_MD **)p2 = smctx->ctx.md;
 		return 1;
 	case EVP_PKEY_CTRL_SET1_ID:

--- a/src/uadk_sm2.c
+++ b/src/uadk_sm2.c
@@ -1204,8 +1204,7 @@ static int sm2_init(EVP_PKEY_CTX *ctx)
 	}
 
 	ret = uadk_init_ecc();
-	if (ret) {
-		fprintf(stderr, "failed to uadk_init_ecc, ret = %d\n", ret);
+	if (ret != UADK_INIT_SUCCESS) {
 		smctx->init_status = CTX_INIT_FAIL;
 		goto end;
 	}

--- a/src/v1/alg/ciphers/sec_ciphers.c
+++ b/src/v1/alg/ciphers/sec_ciphers.c
@@ -64,7 +64,7 @@ static cipher_info_t g_sec_ciphers_info[] = {
 	{NID_sm4_ctr, 1, 16, 16, EVP_CIPH_CTR_MODE, 1, NULL},
 	{NID_sm4_cbc, 16, 16, 16, EVP_CIPH_CBC_MODE | EVP_CIPH_FLAG_DEFAULT_ASN1, 1, NULL},
 	{NID_sm4_ofb128, 1, 16, 16, EVP_CIPH_OFB_MODE, 1, NULL},
-	{NID_sm4_ecb, 16, 16, 0, EVP_CIPH_CTR_MODE, 1, NULL},
+	{NID_sm4_ecb, 16, 16, 0, EVP_CIPH_ECB_MODE, 1, NULL},
 };
 
 #define CIPHERS_COUNT (BLOCKSIZES_OF(g_sec_ciphers_info))

--- a/src/v1/alg/pkey/hpre_rsa.c
+++ b/src/v1/alg/pkey/hpre_rsa.c
@@ -298,13 +298,13 @@ static int hpre_rsa_public_encrypt(int flen, const unsigned char *from,
 	BIGNUM *ret_bn  = NULL;
 	hpre_engine_ctx_t *eng_ctx = NULL;
 	unsigned char *in_buf = NULL;
+	int ret = HPRE_CRYPTO_FAIL;
 	BN_CTX *bn_ctx = NULL;
 	int num_bytes = 0;
 	int key_bits;
-	int ret;
 
 	if (hpre_rsa_check_para(flen, from, to, rsa) != HPRE_CRYPTO_SUCC)
-		return HPRE_CRYPTO_FAIL;
+		return ret;
 
 	key_bits = RSA_bits(rsa);
 	if (!check_bit_useful(key_bits)) {
@@ -392,7 +392,7 @@ static int hpre_rsa_private_encrypt(int flen, const unsigned char *from,
 	int version;
 
 	if (hpre_rsa_check_para(flen, from, to, rsa) != HPRE_CRYPTO_SUCC)
-		return HPRE_CRYPTO_FAIL;
+		return ret;
 
 	key_bits = RSA_bits(rsa);
 	if (!check_bit_useful(key_bits)) {
@@ -479,6 +479,7 @@ static int hpre_rsa_public_decrypt(int flen, const unsigned char *from,
 		unsigned char *to, RSA *rsa, int padding)
 {
 	hpre_engine_ctx_t *eng_ctx = NULL;
+	int ret = HPRE_CRYPTO_FAIL;
 	BIGNUM *bn_ret = NULL;
 	BIGNUM *f = NULL;
 	BN_CTX *bn_ctx = NULL;
@@ -488,10 +489,10 @@ static int hpre_rsa_public_decrypt(int flen, const unsigned char *from,
 	int num_bytes = 0;
 	int rsa_soft_mark = 0;
 	unsigned char *buf = NULL;
-	int ret, len;
+	int len;
 
 	if (hpre_rsa_check_para(flen, from, to, rsa) != HPRE_CRYPTO_SUCC)
-		return HPRE_CRYPTO_FAIL;
+		return ret;
 
 	RSA_get0_key(rsa, &n, &e, &d);
 	ret = hpre_rsa_check(flen, n, e, &num_bytes, rsa);
@@ -578,7 +579,7 @@ static int hpre_rsa_private_decrypt(int flen, const unsigned char *from,
 	BN_CTX *bn_ctx = NULL;
 
 	if (hpre_rsa_check_para(flen, from, to, rsa) != HPRE_CRYPTO_SUCC)
-		return HPRE_CRYPTO_FAIL;
+		return ret;
 
 	RSA_get0_key(rsa, &n, &e, &d);
 	num_bytes = BN_num_bytes(n);

--- a/src/v1/alg/pkey/hpre_wd.c
+++ b/src/v1/alg/pkey/hpre_wd.c
@@ -157,10 +157,13 @@ void hpre_free_eng_ctx(hpre_engine_ctx_t *eng_ctx)
 	}
 
 	if (eng_ctx->opdata.op_type != WCRYPTO_RSA_GENKEY) {
-		if (eng_ctx->opdata.in)
-			eng_ctx->rsa_setup.br.free(eng_ctx->qlist->kae_queue_mem_pool, eng_ctx->opdata.in);
+		if (eng_ctx->opdata.in) {
+			if (eng_ctx->qlist)
+				eng_ctx->rsa_setup.br.free(eng_ctx->qlist->kae_queue_mem_pool, eng_ctx->opdata.in);
+		}
+
 		if (eng_ctx->opdata.out) {
-			if (eng_ctx->qlist != NULL)
+			if (eng_ctx->qlist)
 				eng_ctx->rsa_setup.br.free(eng_ctx->qlist->kae_queue_mem_pool, eng_ctx->opdata.out);
 		}
 	} else {


### PR DESCRIPTION
This patchset contains some bugfix and cleanup.

Hao Fang (6):
  uadk_engine: cipher/digest: fixes for priv address check
  uadk_engine: ec: add BN_new memory check
  uadk_engine: rsa: fix mem leak for from_buf
  uadk_engine: uadk_rsa: fix to free from_buffer
  uadk_engine: uask_async: fix thread_attr res leak
  uadk_engine: async: fix add async send timeout

Qi Tao (3):
  cipher: uadk_e_bind_ciphers function is optimized
  cipher: UADK_CIPHER_DESCR is optimized
  uadk_engine/v1: fix g_sec_ciphers_info[] error

Weili Qian (2):
  uadk_engine: add device initialization status
  sm2: fixup switching soft sm2 decrypt problem

Zhiqi Song (6):
  ecc: optimize sm2 sign check function
  digest: fix the address of async op
  uadk_engine: fixup resource management issues
  ecc: add check of siglen
  v1/pkey: add check of qlist
  v1/pkey: fix uninitialized variable
