### PR TITLE
uadk_cipher: fixup sm4 cfb flags

### DIFF
--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -920,7 +920,7 @@ EVP_CIPHER *uadk_create_cipher_meth(int nid)
 		cipher = uadk_sm4_ofb128;
 		break;
 	case NID_sm4_cfb128:
-		UADK_CIPHER_DESCR(sm4_cfb128, 1, 16, 16, EVP_CIPH_OFB_MODE);
+		UADK_CIPHER_DESCR(sm4_cfb128, 1, 16, 16, EVP_CIPH_CFB_MODE);
 		cipher = uadk_sm4_cfb128;
 		break;
 	case NID_sm4_ctr:


### PR DESCRIPTION
The flags of sm4 cfb should be EVP_CIPH_CFB_MODE,
so fix it.