### PR TITLE
uadk_engine: add secure compilation option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ AC_CONFIG_HEADERS([config.h])
 
 AC_PROG_CC
 LT_INIT
+AC_SUBST([hardcode_into_libs], [no])
 
 AC_ARG_ENABLE(kae,
 	      AS_HELP_STRING([--enable-kae],[Enable kae support]))

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,6 +18,8 @@ uadk_engine_la_LIBADD=-ldl $(WD_LIBS) -lpthread
 uadk_engine_la_LDFLAGS=-module -version-number $(VERSION)
 uadk_engine_la_CFLAGS=$(WD_CFLAGS) $(libcrypto_CFLAGS)
 uadk_engine_la_CFLAGS+=-DCRYPTO
+uadk_engine_la_CFLAGS+=-fPIC -fPIE -pie -fstack-protector-strong -D_FORTIFY_SOURCE=2 \
+		       -O2 -ftrapv -Wl,-z,relro,-z,now -Wl,-s
 
 AUTOMAKE_OPTIONS = subdir-objects
 


### PR DESCRIPTION
Add PIE, PIC, BIND_NOW, SP, FS, NO Rpath/RunPath, Ftrapv and Strip compilation options.