### PR TITLE
uadk_util: fix clang build error

### DIFF
--- a/src/uadk_utils.c
+++ b/src/uadk_utils.c
@@ -50,7 +50,7 @@ static void *memcpy_large(void *dstpp, const void *srcpp, size_t len)
 
 			: [res] "+r"(dstpp)
 			: [src] "r"(srcpp), [count] "r"(len)
-			  : "x3", "x4", "x5", "x14", "q0", "q1"
+			  : "x3", "x4", "x5", "x14", "v0", "v1"
 				  );
 
 	return dstpp;


### PR DESCRIPTION
autoreconf -i
./configure CC=clang
make -j8

reports error:
uadk_utils.c:53:33: error: unknown register name 'q0' in asm uadk_utils.c:53:39: error: unknown register name 'q1' in asm

Fix with "v0", "v1", instead of "q0", "q1"