### PR TITLE
uadk_prov_cipher: do_soft when hw failed

### DIFF
--- a/src/uadk_digest.c
+++ b/src/uadk_digest.c
@@ -202,10 +202,11 @@ static int digest_soft_init(struct digest_priv_ctx *md_ctx)
 	int app_datasize;
 
 	/* Allocate a soft ctx for hardware engine */
-	if (md_ctx->soft_ctx == NULL)
+	if (md_ctx->soft_ctx == NULL) {
 		md_ctx->soft_ctx = EVP_MD_CTX_new();
 		if (md_ctx->soft_ctx == NULL)
 			return 0;
+	}
 
 	ctx = md_ctx->soft_ctx;
 


### PR DESCRIPTION
By default, do_soft is disabled.
To enable sw handling, need set enable_sw_offload = 1 via OPENSSL_CONF

For example: uadk_provider.cnf

openssl_conf = openssl_init

[openssl_init]
providers = provider_sect

[provider_sect]
uadk_provider = uadk_sect

[uadk_sect]
activate = 1
enable_sw_offload = 1

export OPENSSL_CONF=uadk_provider.cnf