### PR TITLE
kmgmt: KEYMGMT struct is different in 3.2

### DIFF
--- a/src/uadk_prov_dh.c
+++ b/src/uadk_prov_dh.c
@@ -248,7 +248,9 @@ typedef struct {
 	OSSL_PROVIDER *prov;
 
 	int refcnt;
+# if OPENSSL_VERSION_NUMBER < 0x30200000
 	void *lock;
+# endif
 
 	/* Constructor(s), destructor, information */
 	OSSL_FUNC_keymgmt_new_fn *new;

--- a/src/uadk_prov_rsa.c
+++ b/src/uadk_prov_rsa.c
@@ -299,7 +299,9 @@ typedef struct{
 	OSSL_PROVIDER *prov;
 
 	int refcnt;
+# if OPENSSL_VERSION_NUMBER < 0x30200000
 	void *lock;
+# endif
 
 	/* Constructor(s), destructor, information */
 	OSSL_FUNC_keymgmt_new_fn *new;


### PR DESCRIPTION
KEYMGMT struct is different in 3.2 causes Segmentation fault. Fixed it by adding version check.