### PR TITLE
cipher_adapter: remote aead in v2

### DIFF
--- a/src/uadk_cipher_adapter.c
+++ b/src/uadk_cipher_adapter.c
@@ -34,9 +34,6 @@ static int cipher_hw_v2_nids[] = {
 	NID_sm4_ecb,
 	NID_des_ede3_cbc,
 	NID_des_ede3_ecb,
-	NID_aes_128_gcm,
-	NID_aes_192_gcm,
-	NID_aes_256_gcm
 };
 
 static int cipher_hw_v3_nids[] = {


### PR DESCRIPTION
v2 does not support aead, causing nginx failure.
log:
do aead update operation failed, ret: -22, state: 0!

nginx works now after removing aead parts.