### PR TITLE
rsa: add RSA_NO_PADDING and RSA_SSLV23_PADDING

### DIFF
--- a/src/uadk_rsa.c
+++ b/src/uadk_rsa.c
@@ -508,6 +508,12 @@ static int add_rsa_pubenc_padding(int flen, const unsigned char *from,
 		if (!ret)
 			fprintf(stderr, "RSA_PKCS1_OAEP_PADDING err\n");
 		break;
+	case RSA_SSLV23_PADDING:
+		ret = RSA_padding_add_SSLv23(buf, num, from, flen);
+		break;
+	case RSA_NO_PADDING:
+		ret = RSA_padding_add_none(buf, num, from, flen);
+		break;
 	default:
 		ret = UADK_E_FAIL;
 	}
@@ -532,6 +538,13 @@ static int check_rsa_pridec_padding(unsigned char *to, int num,
 						   NULL, 0);
 		if (!ret)
 			fprintf(stderr, "RSA_PKCS1_OAEP_PADDING err\n");
+		break;
+	case RSA_SSLV23_PADDING:
+		ret = RSA_padding_check_SSLv23(to, num, buf, len, num);
+		break;
+	case RSA_NO_PADDING:
+		memcpy(to, buf, len);
+		ret = len;
 		break;
 	default:
 		ret = UADK_E_FAIL;
@@ -560,6 +573,9 @@ static int add_rsa_prienc_padding(int flen, const unsigned char *from,
 		if (!ret)
 			fprintf(stderr, "RSA_X931_PADDING err\n");
 		break;
+	case RSA_NO_PADDING:
+		ret = RSA_padding_add_none(to_buf, tlen, from, flen);
+		break;
 	default:
 		ret = UADK_E_FAIL;
 	}
@@ -585,6 +601,10 @@ static int check_rsa_pubdec_padding(unsigned char *to, int num,
 		ret = RSA_padding_check_X931(to, num, buf, len, num);
 		if (!ret)
 			fprintf(stderr, "RSA_X931_PADDING err\n");
+		break;
+	case RSA_NO_PADDING:
+		memcpy(to, buf, len);
+		ret = len;
 		break;
 	default:
 		ret = UADK_E_FAIL;


### PR DESCRIPTION
refer v1, adding RSA_NO_PADDING and RSA_SSLV23_PADDING. otherwise nginx will fail

/usr/local/nginx/conf/nginx.conf
ssl_ciphers  ECDHE-RSA-AES256-GCM-SHA384;
ssl_prefer_server_ciphers  on;

Test:
ab -n 1 -c 1 https://localhost/