### PR TITLE
prov: EVP struct differences in OpenSSL 3.0

### DIFF
--- a/src/uadk_prov_dh.c
+++ b/src/uadk_prov_dh.c
@@ -56,7 +56,9 @@ struct evp_keyexch_st {
 	const char *description;
 	OSSL_PROVIDER *prov;
 	CRYPTO_REF_COUNT refcnt;
-
+# if OPENSSL_VERSION_NUMBER < 0x30200000
+	CRYPTO_RWLOCK *lock;
+# endif
 	OSSL_FUNC_keyexch_newctx_fn *newctx;
 	OSSL_FUNC_keyexch_init_fn *init;
 	OSSL_FUNC_keyexch_set_peer_fn *set_peer;
@@ -247,9 +249,9 @@ typedef struct {
 	const char *description;
 	OSSL_PROVIDER *prov;
 
-	int refcnt;
+	CRYPTO_REF_COUNT refcnt;
 # if OPENSSL_VERSION_NUMBER < 0x30200000
-	void *lock;
+	CRYPTO_RWLOCK *lock;
 # endif
 
 	/* Constructor(s), destructor, information */
@@ -278,8 +280,14 @@ typedef struct {
 	/* Import and export routines */
 	OSSL_FUNC_keymgmt_import_fn *import;
 	OSSL_FUNC_keymgmt_import_types_fn *import_types;
+# if OPENSSL_VERSION_NUMBER >= 0x30200000
+	OSSL_FUNC_keymgmt_import_types_ex_fn *import_types_ex;
+# endif
 	OSSL_FUNC_keymgmt_export_fn *export;
 	OSSL_FUNC_keymgmt_export_types_fn *export_types;
+# if OPENSSL_VERSION_NUMBER >= 0x30200000
+	OSSL_FUNC_keymgmt_export_types_ex_fn *export_types_ex;
+# endif
 	OSSL_FUNC_keymgmt_dup_fn *dup;
 
 } UADK_DH_KEYMGMT;

--- a/src/uadk_prov_rsa.c
+++ b/src/uadk_prov_rsa.c
@@ -241,8 +241,9 @@ struct evp_signature_st {
 	const char *description;
 	OSSL_PROVIDER *prov;
 	CRYPTO_REF_COUNT refcnt;
+# if OPENSSL_VERSION_NUMBER < 0x30200000
 	CRYPTO_RWLOCK *lock;
-
+# endif
 	OSSL_FUNC_signature_newctx_fn *newctx;
 	OSSL_FUNC_signature_sign_init_fn *sign_init;
 	OSSL_FUNC_signature_sign_fn *sign;
@@ -276,8 +277,9 @@ struct evp_asym_cipher_st {
 	const char *description;
 	OSSL_PROVIDER *prov;
 	CRYPTO_REF_COUNT refcnt;
+# if OPENSSL_VERSION_NUMBER < 0x30200000
 	CRYPTO_RWLOCK *lock;
-
+#endif
 	OSSL_FUNC_asym_cipher_newctx_fn *newctx;
 	OSSL_FUNC_asym_cipher_encrypt_init_fn *encrypt_init;
 	OSSL_FUNC_asym_cipher_encrypt_fn *encrypt;
@@ -298,9 +300,9 @@ typedef struct{
 	const char *description;
 	OSSL_PROVIDER *prov;
 
-	int refcnt;
+	CRYPTO_REF_COUNT refcnt;
 # if OPENSSL_VERSION_NUMBER < 0x30200000
-	void *lock;
+	CRYPTO_RWLOCK *lock;
 # endif
 
 	/* Constructor(s), destructor, information */
@@ -329,8 +331,14 @@ typedef struct{
 	/* Import and export routines */
 	OSSL_FUNC_keymgmt_import_fn *import;
 	OSSL_FUNC_keymgmt_import_types_fn *import_types;
+# if OPENSSL_VERSION_NUMBER >= 0x30200000
+	OSSL_FUNC_keymgmt_import_types_ex_fn *import_types_ex;
+# endif
 	OSSL_FUNC_keymgmt_export_fn *export;
 	OSSL_FUNC_keymgmt_export_types_fn *export_types;
+# if OPENSSL_VERSION_NUMBER >= 0x30200000
+	OSSL_FUNC_keymgmt_export_types_ex_fn *export_types_ex;
+# endif
 	OSSL_FUNC_keymgmt_dup_fn *dup;
 } UADK_RSA_KEYMGMT;
 


### PR DESCRIPTION
Issue:

There are structural differences in the evp_keymgmt_st, evp_keyexch_st, and evp_asym_cipher_st structs between OpenSSL 3.2 and 3.0.

vimdiff 3.2/crypto/evp/evp_local.h 3.0/crypto/evp/evp_local.h

Solution:

Version Check:
Introduce a check for OPENSSL_VERSION_NUMBER at compile time.

Version-Specific Builds:
Based on the version, the uadk_provider will be built with the appropriate OpenSSL library to ensure compatibility with the struct definitions.