### PR TITLE
uadk_async: check thread_id before pthread_join

### DIFF
--- a/src/uadk_async.c
+++ b/src/uadk_async.c
@@ -390,7 +390,9 @@ void async_module_uninit(void)
 		return;
 
 	sem_post(&poll_queue.full_sem);
-	pthread_join(poll_queue.thread_id, NULL);
+
+	if (poll_queue.thread_id)
+		pthread_join(poll_queue.thread_id, NULL);
 
 	task = poll_queue.head;
 	if (task)


### PR DESCRIPTION
openssl engine -c uadk_engine
does not call uadk_init & uadk_finish, but call uadk_destroy, which call pthread_join(poll_queue.thread_id) but the thread_id is not initialized, causing segmentation fault in 2403.

Test: 2403
autoreconf -i
make clean
./configure --enable-engine --libdir=/usr/lib64/engines-3/ CFLAGS=-Wall make; make install

openssl engine -c uadk_engine